### PR TITLE
V0 api update

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,7 @@ Run with ``./manage.py test``
 
 SQLite is supported as an alternative to PostgreSQL - update the `DATABASES` setting
 in openstax/settings/base.py to use `'django.db.backends.sqlite3'` and set `NAME` to be the full path of your database file, as you would with a regular Django project.
+
+### APIs
+
+There are two REST APIs that can be used to access webpage content and other resources such as images.  The first is implemented using [Wagtail's API framework](http://docs.wagtail.io/en/v1.0/reference/contrib/api/index.html), and can be accessed through the links ``/api/v1/pages/``, ``/api/v1/images/``, ``/api/v1/documents/``.  The second is implemented using [Django's REST API framework](http://www.django-rest-framework.org/) and can be accessed through the link ``/api/v0``.

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -10,12 +10,14 @@ class DocumentSerializer(serializers.HyperlinkedModelSerializer):
         model = Document
         fields = ('id',
                   'title',
+                  'file',
                   )
 class PageSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = Page
         fields = ('id',
                   'title',
+                  'url',
                   )
 
 class ImageSerializer(serializers.HyperlinkedModelSerializer):

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -1,7 +1,14 @@
 from rest_framework import serializers
 from rest_auth.serializers import UserDetailsSerializer
 from wagtail.wagtailimages.models import Image
+from wagtail.wagtailcore.models import Page
 
+class PageSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = Page
+        fields = ('id',
+                  'title',
+                  )
 
 class ImageSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -2,7 +2,15 @@ from rest_framework import serializers
 from rest_auth.serializers import UserDetailsSerializer
 from wagtail.wagtailimages.models import Image
 from wagtail.wagtailcore.models import Page
+from wagtail.wagtaildocs.models import Document
 
+
+class DocumentSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = Document
+        fields = ('id',
+                  'title',
+                  )
 class PageSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = Page

--- a/api/urls.py
+++ b/api/urls.py
@@ -1,13 +1,14 @@
 from django.conf.urls import include, url
 from rest_framework import routers
-from .views import ImageViewSet, UserView  
+from .views import ImageViewSet, UserView, PageViewSet  
 
 
 router = routers.DefaultRouter()
-router.register(r'v0/images', ImageViewSet)
+router.register(r'images', ImageViewSet)
 router.register(r'user', UserView, 'user')
+router.register(r'pages', PageViewSet)
 
 urlpatterns = [
-    url(r'^', include(router.urls)),
+    url(r'^v0/', include(router.urls)),
 ]
 

--- a/api/urls.py
+++ b/api/urls.py
@@ -1,12 +1,13 @@
 from django.conf.urls import include, url
 from rest_framework import routers
-from .views import ImageViewSet, UserView, PageViewSet  
+from .views import ImageViewSet, UserView, PageViewSet, DocumentViewSet  
 
 
 router = routers.DefaultRouter()
 router.register(r'images', ImageViewSet)
 router.register(r'user', UserView, 'user')
 router.register(r'pages', PageViewSet)
+router.register(r'documents', DocumentViewSet)
 
 urlpatterns = [
     url(r'^v0/', include(router.urls)),

--- a/api/views.py
+++ b/api/views.py
@@ -1,7 +1,13 @@
 from rest_framework import viewsets
 from django.contrib.auth.models import User
-from .serializers import ImageSerializer, UserSerializer
+from .serializers import ImageSerializer, UserSerializer, PageSerializer 
 from wagtail.wagtailimages.models import Image
+from wagtail.wagtailcore.models import Page
+
+
+class PageViewSet(viewsets.ModelViewSet):
+    queryset = Page.objects.all()
+    serializer_class = PageSerializer
 
 class ImageViewSet(viewsets.ModelViewSet):
     queryset = Image.objects.all()

--- a/api/views.py
+++ b/api/views.py
@@ -1,9 +1,13 @@
 from rest_framework import viewsets
 from django.contrib.auth.models import User
-from .serializers import ImageSerializer, UserSerializer, PageSerializer 
+from .serializers import ImageSerializer, UserSerializer, PageSerializer, DocumentSerializer  
 from wagtail.wagtailimages.models import Image
 from wagtail.wagtailcore.models import Page
+from wagtail.wagtaildocs.models import Document
 
+class DocumentViewSet(viewsets.ModelViewSet):
+    queryset = Document.objects.all()
+    serializer_class = DocumentSerializer
 
 class PageViewSet(viewsets.ModelViewSet):
     queryset = Page.objects.all()


### PR DESCRIPTION
Adding Document and Pages to api.  Returned fields can be extended in the ``api/serializers.py`` file. Also changes the v0 api root to be ``/api/v0``. 

Fixes #66 