### PR TITLE
remove domain specific cookie settings

### DIFF
--- a/openstax/settings/base.py
+++ b/openstax/settings/base.py
@@ -89,9 +89,6 @@ STATICFILES_FINDERS = [
 # Make this unique, and don't share it with anybody.
 SECRET_KEY = 'wq21wtjo3@d_qfjvd-#td!%7gfy2updj2z+nev^k$iy%=m4_tr'
 
-# This setting allows for cross domain sessions
-SESSION_COOKIE_DOMAIN = '.openstax.org'
-
 MIDDLEWARE_CLASSES = [
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',

--- a/openstax/settings/local.py.example
+++ b/openstax/settings/local.py.example
@@ -27,8 +27,6 @@ SECRET_KEY = 'enter-a-long-unguessable-string-here'
 #     'INTERCEPT_REDIRECTS': False,
 # }
 
-SESSION_COOKIE_DOMAIN = None # For admin login on localhost
-
 SALESFORCE = { 'username' : '',
                'password' : '', # password might need to be concatinated with security_token e.g. 'mypass1231' 
                'security_token' : '' } 


### PR DESCRIPTION
We no longer need this, since we moved the api and frontend to the same url.