### PR TITLE
/api/user/ and accounts.utils.create_user updates

### DIFF
--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -51,13 +51,13 @@ class Utilities(LiveServerTestCase, WagtailPageTests):
         self.assertNotIn(user_details['username'], usernames)
 
         # create user
-        result = create_user(**user_details)
+        returned_user = create_user(**user_details)
 
         # check the returned result
         self.assertTrue(
             User.objects.filter(username=user_details['username']).exists())
         # User.objects.get(username=user_details['username'])
-        returned_user = result['user']
+
         self.assertTrue(returned_user.social_auth.exists())
         social_user = returned_user.social_auth.first()
         self.assertEqual(social_user.uid, str(user_details['uid']))

--- a/accounts/utils.py
+++ b/accounts/utils.py
@@ -10,4 +10,5 @@ def create_user(**user_details):
     result = openstax.run_pipeline(pipeline=settings.IMPORT_USER_PIPELINE,
                                    details=user_details,
                                    uid=user_details['uid'])
-    return result
+    user = result['user']
+    return user

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -2,7 +2,7 @@ from rest_framework import serializers
 from rest_auth.serializers import UserDetailsSerializer
 from wagtail.wagtailimages.models import Image
 from salesforce.models import Adopter
-
+from social.apps.django_app.default.models import DjangoStorage as SocialAuthStorage
 
 class AdopterSerializer(serializers.HyperlinkedModelSerializer):
 
@@ -29,6 +29,7 @@ class ImageSerializer(serializers.HyperlinkedModelSerializer):
 
 class UserSerializer(UserDetailsSerializer):
     groups = serializers.StringRelatedField(many=True)
+    accounts_id = serializers.CharField(required=True, allow_blank=True)
 
     class Meta(UserDetailsSerializer.Meta):
         fields = ('username',
@@ -36,11 +37,13 @@ class UserSerializer(UserDetailsSerializer):
                   'last_name',
                   'is_staff',
                   'is_superuser',
-                  'groups')
+                  'groups',
+                  'accounts_id',)
         read_only_fields = ('username',
                             'first_name',
                             'last_name',
                             'is_staff',
                             'is_superuser',
-                            'groups')
+                            'groups',
+                            'accounts_id',)
 

--- a/api/tests.py
+++ b/api/tests.py
@@ -8,9 +8,10 @@ from django.contrib.auth.models import User
 from accounts.utils import create_user
 from wagtail.tests.utils import WagtailPageTests
 import time
+from api.serializers import UserSerializer
 
 
-class SalesforceAPI(LiveServerTestCase, WagtailPageTests):
+class UserAPI(LiveServerTestCase, WagtailPageTests):
     serialized_rollback = True
 
     def setUp(self):
@@ -18,6 +19,37 @@ class SalesforceAPI(LiveServerTestCase, WagtailPageTests):
         super(WagtailPageTests, self).setUp()
         [user.delete() for user in User.objects.all()]
 
+    def test_anonymous_user_fields(self):
+        response = self.client.get('/api/user/?format=json')
+        user_list = json.loads(response.content.decode(response.charset))
+        self.assertEqual(len(user_list), 1)
+        user_dict = user_list[0]
+        returned_set = set(user_dict.keys())
+        expected_set = set(
+            ['username', 'accounts_id', 'is_superuser', 'groups', 'is_staff'])
+        self.assertSetEqual(expected_set, returned_set)
+
+    def test_logged_in_user_fields(self):
+        test_user = {'last_name': 'last_name',
+                     'username': 'username',
+                     'full_name': None,
+                     'first_name': 'first_name',
+                     'uid': '0'}
+
+        result = create_user(**test_user)
+        new_user = result['user']
+        self.client.force_login(new_user)
+        response = self.client.get('/api/user/?format=json')
+        user_list = json.loads(response.content.decode(response.charset))
+        self.assertEqual(len(user_list), 1)
+        user_dict = user_list[0]
+        returned_set = set(user_dict.keys())
+        expected_set = set(UserSerializer.Meta.fields)
+        self.assertSetEqual(expected_set, returned_set)
+        self.assertEqual(user_dict['accounts_id'], test_user['uid'])
+        self.assertEqual(user_dict['username'], test_user['username'])
+        self.assertEqual(user_dict['first_name'], test_user['first_name'])
+        self.assertEqual(user_dict['last_name'], test_user['last_name'])
     def test_user_faculty_group(self):
         user = User.objects.create_user('john',
                                         'lennon@thebeatles.com',
@@ -32,7 +64,8 @@ class SalesforceAPI(LiveServerTestCase, WagtailPageTests):
                               'first_name': '',
                               'groups': [],
                               'last_name': '',
-                              'is_staff': False}
+                              'is_staff': False,
+                              'accounts_id': None}
         returned_user_info = response_list[0]
         self.assertDictEqual(expected_user_info, returned_user_info)
 
@@ -40,7 +73,7 @@ class SalesforceAPI(LiveServerTestCase, WagtailPageTests):
                      'username': 'username',
                      'full_name': None,
                      'first_name': 'first_name',
-                     'uid': 0}
+                     'uid': '0'}
 
         result = create_user(**test_user)
         new_user = result['user']
@@ -55,7 +88,8 @@ class SalesforceAPI(LiveServerTestCase, WagtailPageTests):
                               'first_name': 'first_name',
                               'groups': ['Faculty'],
                               'last_name': 'last_name',
-                              'is_staff': False}
+                              'is_staff': False,
+                              'accounts_id': '0'}
         returned_user_info = response_list[0]
         self.assertDictEqual(expected_user_info, returned_user_info)
 

--- a/api/tests.py
+++ b/api/tests.py
@@ -36,8 +36,8 @@ class UserAPI(LiveServerTestCase, WagtailPageTests):
                      'first_name': 'first_name',
                      'uid': '0'}
 
-        result = create_user(**test_user)
-        new_user = result['user']
+        new_user = create_user(**test_user)
+
         self.client.force_login(new_user)
         response = self.client.get('/api/user/?format=json')
         user_list = json.loads(response.content.decode(response.charset))
@@ -75,8 +75,8 @@ class UserAPI(LiveServerTestCase, WagtailPageTests):
                      'first_name': 'first_name',
                      'uid': '0'}
 
-        result = create_user(**test_user)
-        new_user = result['user']
+        new_user = create_user(**test_user)
+
         self.client.force_login(new_user)
         self.client.get('/api/user/')
         time.sleep(1)

--- a/api/views.py
+++ b/api/views.py
@@ -4,7 +4,7 @@ from wagtail.wagtailimages.models import Image
 from salesforce.models import Adopter
 from django.utils.six import StringIO
 from django.core.management import call_command
-
+from social.apps.django_app.default.models import DjangoStorage as SocialAuthStorage
 
 class AdopterViewSet(viewsets.ModelViewSet):
     queryset = Adopter.objects.all()
@@ -21,11 +21,19 @@ class UserView(viewsets.ModelViewSet):
 
     def get_queryset(self):
         user = self.request.user
+
+        try:
+            social_auth = SocialAuthStorage.user.get_social_auth_for_user(user)
+            user.accounts_id = social_auth[0].uid
+        except:
+            user.accounts_id = None
+
         try:
             out = StringIO()
             call_command('update_faculty_status', str(user.pk), stdout=out)
         except:
             pass
+
         return [user]
 
 

--- a/salesforce/tests.py
+++ b/salesforce/tests.py
@@ -107,8 +107,8 @@ class SalesforceTest(LiveServerTestCase, WagtailPageTests):
                      'full_name': None,
                      'first_name': 'first_name',
                      'uid': 0}
-        result = create_user(**test_user)
-        returned_user = result['user']
+        returned_user = create_user(**test_user)
+
         out = StringIO()
         cms_id = str(returned_user.pk)
         self.assertFalse(returned_user.groups.filter(name='Faculty').exists())
@@ -124,8 +124,8 @@ class SalesforceTest(LiveServerTestCase, WagtailPageTests):
                         'full_name': None,
                         'first_name': 'Richard',
                         'uid': 16207}
-        result = create_user(**user_details)
-        test_user = result['user']
+        test_user = create_user(**user_details)
+
         self.assertFalse(test_user.groups.filter(name='Faculty').exists())
         out = StringIO()
         call_command('update_faculty_status', '--all', stdout=out)


### PR DESCRIPTION
- ``/api/user/`` update adds ``accounts_id`` to queries.
- ``accounts.utils.create_user`` update changes the return value to a ``User`` object. 