### PR TITLE
remove custom 404 handler

### DIFF
--- a/openstax/urls.py
+++ b/openstax/urls.py
@@ -28,7 +28,6 @@ urlpatterns = [
     # Wagtail's serving mechanism
     url(r'', include(wagtail_urls)),
 ]
-handler404 = 'openstax.views.handle_page_not_found_404'
 
 if settings.DEBUG:
     from django.contrib.staticfiles.urls import staticfiles_urlpatterns

--- a/openstax/views.py
+++ b/openstax/views.py
@@ -1,5 +1,0 @@
-from django.shortcuts import redirect
-
-
-def handle_page_not_found_404(request):
-    return redirect('/404')


### PR DESCRIPTION
This is causing an issue with custom redirects, where they don't work while Debug=False.
Removing so it doesn't break the next deploy.