### PR TITLE
remove SF checks from user api endpoint

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -26,20 +26,5 @@ class UserView(viewsets.ModelViewSet):
     def get_queryset(self):
         user = self.request.user
 
-        try:
-            social_auth = SocialAuthStorage.user.get_social_auth_for_user(user)
-            user.accounts_id = social_auth[0].uid
-        except:
-            user.accounts_id = None
-
-        try:
-            out = StringIO()
-            call_command('update_faculty_status', str(user.pk), stdout=out)
-        except:
-            pass
-
-        # check if there is a record in salesforce for this user - if so, they are pending verification
-        user.pending_verification = check_if_faculty_pending(user.pk)
-
         return [user]
 


### PR DESCRIPTION
this will temporarily fix the site being down since SF API requests are over the limit