### PR TITLE
Remove errata API filters

### DIFF
--- a/errata/serializers.py
+++ b/errata/serializers.py
@@ -17,6 +17,7 @@ class ErrataSerializer(serializers.ModelSerializer):
                   'reviewed_date',
                   'corrected_date',
                   'archived',
+                  'is_assessment_errata',
                   'location',
                   'detail',
                   'short_detail',

--- a/errata/views.py
+++ b/errata/views.py
@@ -29,7 +29,7 @@ class ErrataFilter(FilterSet):
 
 
 class ErrataView(ModelViewSet):
-    queryset = Errata.objects.filter(archived=False).exclude(is_assessment_errata='Yes')
+    queryset = Errata.objects
     serializer_class = ErrataSerializer
     http_method_names = ['get', 'post', 'head']
     filter_backends = (DjangoFilterBackend, OrderingFilter)

--- a/errata/views.py
+++ b/errata/views.py
@@ -22,14 +22,15 @@ class JSONResponse(HttpResponse):
 class ErrataFilter(FilterSet):
     book_title = django_filters.CharFilter(name='book__title')
     book_id = django_filters.CharFilter(name='book__id')
+    is_assessment_errata__not = django_filters.CharFilter(name='is_assessment_errata', exclude=True)
 
     class Meta:
         model = Errata
-        fields = ['book_title', 'book_id', 'archived']
+        fields = ['book_title', 'book_id', 'archived', 'is_assessment_errata', 'is_assessment_errata__not']
 
 
 class ErrataView(ModelViewSet):
-    queryset = Errata.objects
+    queryset = Errata.objects.all()
     serializer_class = ErrataSerializer
     http_method_names = ['get', 'post', 'head']
     filter_backends = (DjangoFilterBackend, OrderingFilter)


### PR DESCRIPTION
FE should add these filters to the API endpoint as needed, so that all errata is accessible at the detail page.