### PR TITLE
move wagtailimportexport to project to fix a bug

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -32,7 +32,7 @@ six==1.11.0
 sphinx-me==0.3
 Unidecode==1.0.22
 wagtail==2.3
-wagtail-import-export==0.1
+#wagtail-import-export==0.1 # this has a bug, incorporating in project until fixed
 wheel==0.24.0
 Willow==1.1
 python-social-auth==0.3.6

--- a/wagtailimportexport/__init__.py
+++ b/wagtailimportexport/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'wagtailimportexport.apps.WagtailImportExportAppConfig'

--- a/wagtailimportexport/admin_urls.py
+++ b/wagtailimportexport/admin_urls.py
@@ -1,0 +1,12 @@
+from django.conf.urls import url
+
+from wagtailimportexport import views
+
+
+app_name = 'wagtailimportexport_admin'
+urlpatterns = [
+    url(r'^import_from_api/$', views.import_from_api, name='import_from_api'),
+    url(r'^import_from_file/$', views.import_from_file, name='import_from_file'),
+    url(r'^export_to_file/$', views.export_to_file, name='export_to_file'),
+    url(r'^$', views.index, name='index'),
+]

--- a/wagtailimportexport/apps.py
+++ b/wagtailimportexport/apps.py
@@ -1,0 +1,8 @@
+from django.apps import AppConfig
+from django.utils.translation import ugettext_lazy as _
+
+
+class WagtailImportExportAppConfig(AppConfig):
+    name = 'wagtailimportexport'
+    label = 'wagtailimportexport'
+    verbose_name = _("Wagtail import-export")

--- a/wagtailimportexport/compat.py
+++ b/wagtailimportexport/compat.py
@@ -1,0 +1,16 @@
+try:
+    from wagtail.admin import messages
+    from wagtail.admin.menu import MenuItem
+    from wagtail.admin.widgets import AdminPageChooser
+    from wagtail.core import hooks
+    from wagtail.core.models import Page
+
+    WAGTAIL_VERSION_2_OR_GREATER = True
+except ImportError:  # fallback for Wagtail <2.0
+    from wagtail.wagtailadmin import messages
+    from wagtail.wagtailadmin.menu import MenuItem
+    from wagtail.wagtailadmin.widgets import AdminPageChooser
+    from wagtail.wagtailcore import hooks
+    from wagtail.wagtailcore.models import Page
+
+    WAGTAIL_VERSION_2_OR_GREATER = False

--- a/wagtailimportexport/exporting.py
+++ b/wagtailimportexport/exporting.py
@@ -1,0 +1,42 @@
+import json
+
+from wagtailimportexport.compat import Page
+
+
+def export_pages(root_page, export_unpublished=False):
+    """
+    Create a JSON defintion of part of a site's page tree starting
+    from root_page and descending into its descendants
+
+    By default only published pages are exported.
+
+    If a page is unpublished it and all its descendants are pruned even
+    if some of those descendants are themselves published. This ensures
+    that there are no orphan pages when the subtree is created in the
+    destination site.
+
+    If export_unpublished=True the root_page and all its descendants
+    are included.
+    """
+    root_page = Page.objects.get(id=root_page)
+
+    pages = Page.objects.descendant_of(root_page, inclusive=True).order_by('path').specific()
+    if not export_unpublished:
+        pages = pages.filter(live=True)
+
+    page_data = []
+    exported_paths = set()
+    for (i, page) in enumerate(pages):
+        parent_path = page.path[:-(Page.steplen)]
+        # skip over pages whose parents haven't already been exported
+        # (which means that export_unpublished is false and the parent was unpublished)
+        if i == 0 or (parent_path in exported_paths):
+            page_data.append({
+                'content': json.loads(page.to_json()),
+                'model': page.content_type.model,
+                'app_label': page.content_type.app_label,
+            })
+            exported_paths.add(page.path)
+    return {
+        'pages': page_data
+    }

--- a/wagtailimportexport/forms.py
+++ b/wagtailimportexport/forms.py
@@ -1,0 +1,27 @@
+from django import forms
+from django.utils.translation import ugettext as _
+
+from wagtailimportexport.compat import AdminPageChooser, Page, WAGTAIL_VERSION_2_OR_GREATER
+
+
+admin_page_params = {
+    'can_choose_root': True,
+}
+
+if WAGTAIL_VERSION_2_OR_GREATER:
+    admin_page_params['user_perms'] = 'copy_to'
+
+
+class ImportFromAPIForm(forms.Form):
+    source_page_id = forms.IntegerField()
+    source_site_base_url = forms.URLField()
+    parent_page = forms.IntegerField()
+
+
+class ImportFromFileForm(forms.Form):
+    file = forms.FileField(label=_("File to import"))
+    parent_page = forms.IntegerField()
+
+
+class ExportForm(forms.Form):
+    root_page = forms.IntegerField()

--- a/wagtailimportexport/importing.py
+++ b/wagtailimportexport/importing.py
@@ -1,0 +1,91 @@
+from django.apps import apps
+from django.contrib.contenttypes.models import ContentType
+from django.db import models, transaction
+from modelcluster.models import get_all_child_relations
+
+from wagtailimportexport.compat import Page
+
+
+@transaction.atomic()
+def import_pages(import_data, parent_page):
+    """
+    Take a JSON export of part of a source site's page tree
+    and create those pages under the parent page
+    """
+    pages_by_original_path = {}
+    pages_by_original_id = {}
+
+    parent_page = Page.objects.get(id=parent_page)
+
+    # First create the base Page records; these contain no foreign keys, so this allows us to
+    # build a complete mapping from old IDs to new IDs before we go on to importing the
+    # specific page models, which may require us to rewrite page IDs within foreign keys / rich
+    # text / streamfields.
+    page_content_type = ContentType.objects.get_for_model(Page)
+    for (i, page_record) in enumerate(import_data['pages']):
+        # build a base Page instance from the exported content (so that we pick up its title and other
+        # core attributes)
+        page = Page.from_serializable_data(page_record['content'])
+        original_path = page.path
+        original_id = page.id
+
+        # clear id and treebeard-related fields so that they get reassigned when we save via add_child
+        page.id = None
+        page.path = None
+        page.depth = None
+        page.numchild = 0
+        page.url_path = None
+        page.content_type = page_content_type
+        if i == 0:
+            parent_page.add_child(instance=page)
+        else:
+            # Child pages are created in the same sibling path order as the
+            # source tree because the export is ordered by path
+            parent_path = original_path[:-(Page.steplen)]
+            pages_by_original_path[parent_path].add_child(instance=page)
+
+        pages_by_original_path[original_path] = page
+        pages_by_original_id[original_id] = page
+
+    for (i, page_record) in enumerate(import_data['pages']):
+        # Get the page model of the source page by app_label and model name
+        # The content type ID of the source page is not in general the same
+        # between the source and destination sites but the page model needs
+        # to exist on both.
+        # Raises LookupError exception if there is no matching model
+        model = apps.get_model(page_record['app_label'], page_record['model'])
+
+        specific_page = model.from_serializable_data(page_record['content'], check_fks=False, strict_fks=False)
+        base_page = pages_by_original_id[specific_page.id]
+        specific_page.page_ptr = base_page
+        specific_page.__dict__.update(base_page.__dict__)
+        specific_page.content_type = ContentType.objects.get_for_model(model)
+        update_page_references(specific_page, pages_by_original_id)
+        specific_page.save()
+
+    return len(import_data['pages'])
+
+
+def update_page_references(model, pages_by_original_id):
+    for field in model._meta.get_fields():
+        if isinstance(field, models.ForeignKey) and issubclass(field.related_model, Page):
+            linked_page_id = getattr(model, field.attname)
+            try:
+                # see if the linked page is one of the ones we're importing
+                linked_page = pages_by_original_id[linked_page_id]
+            except KeyError:
+                # any references to pages outside of the import should be left unchanged
+                continue
+
+            # update fk to the linked page's new ID
+            setattr(model, field.attname, linked_page.id)
+
+    # update references within inline child models, including the ParentalKey pointing back
+    # to the page
+    for rel in get_all_child_relations(model):
+        for child in getattr(model, rel.name).all():
+            # reset the child model's PK so that it will be inserted as a new record
+            # rather than updating an existing one
+            child.pk = None
+            # update page references on the child model, including the ParentalKey
+            update_page_references(child, pages_by_original_id)

--- a/wagtailimportexport/templates/wagtailimportexport/export_to_file.html
+++ b/wagtailimportexport/templates/wagtailimportexport/export_to_file.html
@@ -1,0 +1,25 @@
+{% extends "wagtailadmin/base.html" %}
+{% load i18n %}
+{% block titletag %}{% blocktrans %}Export pages{% endblocktrans %}{% endblock %}
+{% block content %}
+    {% trans "Export pages" as title_str %}
+    {% include "wagtailadmin/shared/header.html" with title=title_str icon="download" %}
+
+    <div class="nice-padding">
+        <form action="{% url 'wagtailimportexport_admin:export_to_file' %}" method="POST" novalidate>
+            {% csrf_token %}
+            <ul class="fields">
+                {% for field in form %}
+                    {% include "wagtailadmin/shared/field_as_li.html" %}
+                {% endfor %}
+            </ul>
+
+            <input type="submit" value="{% trans 'Export' %}" class="button">
+        </form>
+    </div>
+{% endblock %}
+
+{% block extra_js %}
+    {{ block.super }}
+    {% include "wagtailadmin/pages/_editor_js.html" %}
+{% endblock %}

--- a/wagtailimportexport/templates/wagtailimportexport/import_from_api.html
+++ b/wagtailimportexport/templates/wagtailimportexport/import_from_api.html
@@ -1,0 +1,25 @@
+{% extends "wagtailadmin/base.html" %}
+{% load i18n %}
+{% block titletag %}{% blocktrans %}Import pages{% endblocktrans %}{% endblock %}
+{% block content %}
+    {% trans "Import pages" as title_str %}
+    {% include "wagtailadmin/shared/header.html" with title=title_str icon="download" %}
+
+    <div class="nice-padding">
+        <form action="{% url 'wagtailimportexport_admin:import_from_api' %}" method="POST" novalidate>
+            {% csrf_token %}
+            <ul class="fields">
+                {% for field in form %}
+                    {% include "wagtailadmin/shared/field_as_li.html" %}
+                {% endfor %}
+            </ul>
+
+            <input type="submit" value="{% trans 'Import' %}" class="button">
+        </form>
+    </div>
+{% endblock %}
+
+{% block extra_js %}
+    {{ block.super }}
+    {% include "wagtailadmin/pages/_editor_js.html" %}
+{% endblock %}

--- a/wagtailimportexport/templates/wagtailimportexport/import_from_file.html
+++ b/wagtailimportexport/templates/wagtailimportexport/import_from_file.html
@@ -1,0 +1,25 @@
+{% extends "wagtailadmin/base.html" %}
+{% load i18n %}
+{% block titletag %}{% blocktrans %}Import pages{% endblocktrans %}{% endblock %}
+{% block content %}
+    {% trans "Import pages" as title_str %}
+    {% include "wagtailadmin/shared/header.html" with title=title_str icon="download" %}
+
+    <div class="nice-padding">
+        <form action="{% url 'wagtailimportexport_admin:import_from_file' %}" enctype="multipart/form-data" method="POST" novalidate>
+            {% csrf_token %}
+            <ul class="fields">
+                {% for field in form %}
+                    {% include "wagtailadmin/shared/field_as_li.html" %}
+                {% endfor %}
+            </ul>
+
+            <input type="submit" value="{% trans 'Import' %}" class="button">
+        </form>
+    </div>
+{% endblock %}
+
+{% block extra_js %}
+    {{ block.super }}
+    {% include "wagtailadmin/pages/_editor_js.html" %}
+{% endblock %}

--- a/wagtailimportexport/templates/wagtailimportexport/index.html
+++ b/wagtailimportexport/templates/wagtailimportexport/index.html
@@ -1,0 +1,15 @@
+{% extends "wagtailadmin/base.html" %}
+{% load i18n %}
+{% block titletag %}{% blocktrans %}Import / export pages{% endblocktrans %}{% endblock %}
+{% block content %}
+    {% trans "Import / export pages" as title_str %}
+    {% include "wagtailadmin/shared/header.html" with title=title_str icon="download" %}
+
+    <div class="nice-padding">
+        <ul>
+            <li><a href="{% url 'wagtailimportexport_admin:import_from_api' %}">{% trans "Import from API" %}</a></li>
+            <li><a href="{% url 'wagtailimportexport_admin:import_from_file' %}">{% trans "Import from file" %}</a></li>
+            <li><a href="{% url 'wagtailimportexport_admin:export_to_file' %}">{% trans "Export to file" %}</a></li>
+        </ul>
+    </div>
+{% endblock %}

--- a/wagtailimportexport/urls.py
+++ b/wagtailimportexport/urls.py
@@ -1,0 +1,15 @@
+from django.conf import settings
+from django.conf.urls import url
+
+from wagtailimportexport import views
+
+
+app_name = 'wagtailimportexport'
+urlpatterns = [
+    url(r'^export/(?P<page_id>\d+)/$', views.export, name='export'),
+]
+
+if getattr(settings, "WAGTAILIMPORTEXPORT_EXPORT_UNPUBLISHED", False):
+    urlpatterns += urlpatterns + [
+        url(r'^export/(?P<page_id>\d+)/all/$', views.export, {'export_unpublished': True}, name='export'),
+    ]

--- a/wagtailimportexport/views.py
+++ b/wagtailimportexport/views.py
@@ -1,0 +1,137 @@
+import json
+import re
+
+from django.http import JsonResponse
+from django.shortcuts import redirect, render
+from django.urls import reverse
+from django.utils.translation import ungettext, ugettext_lazy as _
+
+import requests
+
+from wagtailimportexport.compat import messages, Page
+from wagtailimportexport.exporting import export_pages
+from wagtailimportexport.forms import ExportForm, ImportFromAPIForm, ImportFromFileForm
+from wagtailimportexport.importing import import_pages
+
+
+def index(request):
+    return render(request, 'wagtailimportexport/index.html')
+
+
+def import_from_api(request):
+    """
+    Import a part of a source site's page tree via a direct API request from
+    this Wagtail Admin to the source site
+
+    The source site's base url and the source page id of the point in the
+    tree to import defined what to import and the destination parent page
+    defines where to import it to.
+    """
+    if request.method == 'POST':
+        form = ImportFromAPIForm(request.POST)
+        if form.is_valid():
+            # remove trailing slash from base url
+            base_url = re.sub(r'\/$', '', form.cleaned_data['source_site_base_url'])
+            import_url = (
+                base_url + reverse('wagtailimportexport:export', args=[form.cleaned_data['source_page_id']])
+            )
+            r = requests.get(import_url)
+            import_data = r.json()
+            parent_page = form.cleaned_data['parent_page']
+
+            try:
+                page_count = import_pages(import_data, parent_page)
+            except LookupError as e:
+                messages.error(request, _(
+                    "Import failed: %(reason)s") % {'reason': e}
+                )
+            else:
+                messages.success(request, ungettext(
+                    "%(count)s page imported.",
+                    "%(count)s pages imported.",
+                    page_count) % {'count': page_count}
+                )
+            return redirect('wagtailadmin_explore', parent_page)
+    else:
+        form = ImportFromAPIForm()
+
+    return render(request, 'wagtailimportexport/import_from_api.html', {
+        'form': form,
+    })
+
+
+def import_from_file(request):
+    """
+    Import a part of a source site's page tree via an import of a JSON file
+    exported to a user's filesystem from the source site's Wagtail Admin
+
+    The source site's base url and the source page id of the point in the
+    tree to import defined what to import and the destination parent page
+    defines where to import it to.
+    """
+    if request.method == 'POST':
+        form = ImportFromFileForm(request.POST, request.FILES)
+        if form.is_valid():
+            import_data = json.loads(form.cleaned_data['file'].read().decode('utf-8-sig'))
+            parent_page = form.cleaned_data['parent_page']
+
+            try:
+                page_count = import_pages(import_data, parent_page)
+            except LookupError as e:
+                messages.error(request, _(
+                    "Import failed: %(reason)s") % {'reason': e}
+                )
+            else:
+                messages.success(request, ungettext(
+                    "%(count)s page imported.",
+                    "%(count)s pages imported.",
+                    page_count) % {'count': page_count}
+                )
+            return redirect('wagtailadmin_explore', parent_page)
+    else:
+        form = ImportFromFileForm()
+
+    return render(request, 'wagtailimportexport/import_from_file.html', {
+        'form': form,
+    })
+
+
+def export_to_file(request):
+    """
+    Export a part of this source site's page tree to a JSON file
+    on this user's filesystem for subsequent import in a destination
+    site's Wagtail Admin
+    """
+    if request.method == 'POST':
+        form = ExportForm(request.POST)
+        if form.is_valid():
+            payload = export_pages(form.cleaned_data['root_page'], export_unpublished=True)
+            response = JsonResponse(payload)
+            response['Content-Disposition'] = 'attachment; filename="export.json"'
+            return response
+    else:
+        form = ExportForm()
+
+    return render(request, 'wagtailimportexport/export_to_file.html', {
+        'form': form,
+    })
+
+
+def export(request, page_id, export_unpublished=False):
+    """
+    API endpoint of this source site to export a part of the page tree
+    rooted at page_id
+
+    Requests are made by a destination site's import_from_api view.
+    """
+    try:
+        if export_unpublished:
+            root_page = Page.objects.get(id=page_id)
+        else:
+            root_page = Page.objects.get(id=page_id, live=True)
+    except Page.DoesNotExist:
+        return JsonResponse({'error': _('page not found')})
+
+    payload = export_pages(root_page, export_unpublished=export_unpublished)
+
+    return JsonResponse(payload)

--- a/wagtailimportexport/wagtail_hooks.py
+++ b/wagtailimportexport/wagtail_hooks.py
@@ -1,0 +1,25 @@
+from django.conf.urls import include, url
+from django.urls import reverse
+from django.utils.translation import ugettext_lazy as _
+
+from wagtailimportexport import admin_urls
+from wagtailimportexport.compat import hooks, MenuItem
+
+
+@hooks.register('register_admin_urls')
+def register_admin_urls():
+    return [
+        url(r'^import-export/', include(admin_urls, namespace='wagtailimportexport_admin')),
+    ]
+
+
+class ImportExportMenuItem(MenuItem):
+    def is_shown(self, request):
+        return request.user.is_superuser
+
+
+@hooks.register('register_admin_menu_item')
+def register_import_export_menu_item():
+    return ImportExportMenuItem(
+        _('Import / Export'), reverse('wagtailimportexport_admin:index'), classnames='icon icon-download', order=800
+    )


### PR DESCRIPTION
I've submitted a PR to the import-export project. Once merged, we can go back to using Pypy... until then, this allows using it by ID.