### PR TITLE
add docker for local development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,14 @@ FROM python:3.6-slim
 
 ENV PYTHONUNBUFFERED 1
 
-RUN apt-get update
-RUN apt-get -y install git
-RUN apt-get -y install gcc
-RUN apt-get -y install libxml2-dev libxslt1-dev libz-dev
-
-RUN mkdir /code
+RUN apt-get update && \
+  apt-get install -y --no-install-recommends \
+  git \
+  gcc \
+  libxml2-dev \
+  libxslt1-dev \
+  libz-dev \
+  && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /code
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM python:3.6-slim
+
+ENV PYTHONUNBUFFERED 1
+
+RUN apt-get update
+RUN apt-get -y install git
+RUN apt-get -y install gcc
+RUN apt-get -y install libxml2-dev libxslt1-dev libz-dev
+
+RUN mkdir /code
+
+WORKDIR /code
+
+COPY . /code/
+RUN pip install -r requirements/dev.txt
+
+ENTRYPOINT ["/code/docker/entrypoint"]
+
+ENV DJANGO_SETTINGS_MODULE openstax.settings.docker
+
+CMD docker/start

--- a/README.md
+++ b/README.md
@@ -35,30 +35,68 @@ Run with ``python3 manage.py test --liveserver=localhost:8001 --settings=opensta
 SQLite is supported as an alternative to PostgreSQL - update the `DATABASES` setting
 in openstax/settings/base.py to use `'django.db.backends.sqlite3'` and set `NAME` to be the full path of your database file, as you would with a regular Django project.
 
+### Docker
+
+To run the CMS in Docker containers:
+
+```
+$> docker-compose up
+```
+
+The CMS code directory from your host machine is mounted in the `app` container at `/code`
+
+To drop into a bash terminal in the `app` container:
+
+```
+$> docker-compose exec -e DJANGO_SETTINGS_MODULE=openstax.settings.docker app bash
+```
+
+This command has been wrapped in a tiny script
+
+```
+$> ./docker/bash
+```
+
+From within the bash shell, you can run the tests.
+
+```
+$> python3 manage.py test --keepdb
+```
+
+or pound on a specific test
+
+```
+$> python3 manage.py test --keepdb books.tests.BookTests.test_can_create_book
+```
+
+The `--keepdb` option reuses the test database from run to run so you don't have to wait for it to recreate the database and run the migrations every time.
+
+To debug tests, you can insert the normal `import pdb; pdb.set_trace()` lines in your code and test runs from the bash environment will show you the debugger.
+
 ### API Endpoints
 `/api/v2` - Wagtails API. This serves things like pages, images, and documents - except when it doesn't, see below for exceptions.
 
 `/api/v2/pages` (mostly used with `/api/v2/pages/?slug=[slug]`) returns the `detail_url` for the page content. You can also call `/api/v2/pages` and get a list of all pages with their `detail_url` and `slug`.
- 
+
  `/api/snippets/roles` - Returns list of available roles for a user. This lives in the `snippets` directory.
- 
+
  `/api/sticky` - Returns the text for the sticky note. Lives in the `api` directory.
- 
+
  `/api/footer` - Returns the text for the footer. Lives in the `api` directory.
- 
+
  `/api/errata/[id]` - Returns details for a piece of Errata
- 
+
  `/api/books` - Returns a list of books, with their slug and some information needed to render the subjects page
- 
- `/api/mail/send_mail` - Takes post parameters and sends mail through Amazon SES. We prevent spamming by only having a limited set of subjects that it will accept and go to a particular email address. 
- 
+
+ `/api/mail/send_mail` - Takes post parameters and sends mail through Amazon SES. We prevent spamming by only having a limited set of subjects that it will accept and go to a particular email address.
+
  `/api/documents` - Custom API endpoint to return all documents with their cloudfront url, this lives in the `api` directory
- 
+
  `/api/images` - Custom API endpoint to return all images with their cloudfront url, this lives in the `api` directory.
- 
+
  `/api/progress` - Custom API endpoint that allows writing user progress through the instructor process. This takes an `account_id` and `progress` (integer representation of the users progress, 1-5). You can query using `?account_id=[id]` to retrieve progress.
- 
- `/api/salesforce/schools` and `/api/schools` - Returns a list of adoption schools from Salesforce. 
+
+ `/api/salesforce/schools` and `/api/schools` - Returns a list of adoption schools from Salesforce.
  You can also filter on this API by the following fields:
  - `name` [string]
  - `id` [int]
@@ -69,17 +107,17 @@ in openstax/settings/base.py to use `'django.db.backends.sqlite3'` and set `NAME
  - `key_institutional_partner` [bool]
  - `achieving_the_dream_school` [bool]
  - `testimonial` [bool]
- 
- 
+
+
 
  These are convience endpoints. They redirect to the Wagtail API v2 endpoint (`/api/v2/pages/[id]`)
- 
+
  `/api/books` - Returns a list of books, with their slug and some information needed to render the subjects page. Wagtail API endpoint: `/api/v2/pages/?slug=subjects`.
- 
+
  `/api/books/[slug]` - Returns details about a book. Wagtail API endoint: `/api/v2/pages/?slug=[book-slug]`.
- 
+
  `/api/news` - Returns the content of the news pages and a list of articles. Wagtail API endpoint: `/api/v2/pages/?slug=openstax-news`.
- 
+
  `/api/news/[slug]` - Returns the content of a news article. Wagtail API endpoint: `/api/v2/pages/?slug=[news-article=slug]`.
- 
+
  `/api/pages` - Returns a page based on slug, eg. `/api/pages/openstax-homepage`. Wagtail API endpoint: `/api/v2/pages/?slug=openstax-homepage`.

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,29 @@
+version: '3.5'
+services:
+  app:
+    build: .
+    ports:
+      - "8000:8000"
+    volumes:
+      - .:/code
+    networks:
+      - openstax
+    links:
+      - postgres
+    depends_on:
+      - postgres
+  postgres:
+    image: "postgres:9.5"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    networks:
+      - openstax
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=password
+      - POSTGRES_DB=openstax
+networks:
+  openstax:
+    name: openstax
+volumes:
+  pgdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,4 @@
+version: '3.5'
+services:
+  app:
+    image: "openstax/openstax-cms"

--- a/docker/bash
+++ b/docker/bash
@@ -1,0 +1,1 @@
+docker-compose exec -e DJANGO_SETTINGS_MODULE=openstax.settings.docker app bash

--- a/docker/entrypoint
+++ b/docker/entrypoint
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
+# uncomment this to load docker secrets into environment variables
 # export $(egrep  -v '^#'  /run/secrets/* | xargs)
 
 exec "$@"

--- a/docker/entrypoint
+++ b/docker/entrypoint
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+
+# export $(egrep  -v '^#'  /run/secrets/* | xargs)
+
+exec "$@"

--- a/docker/start
+++ b/docker/start
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+DJANGO_SETTINGS_MODULE=openstax.settings.docker python3 manage.py migrate
+DJANGO_SETTINGS_MODULE=openstax.settings.docker python3 manage.py createsuperuser
+DJANGO_SETTINGS_MODULE=openstax.settings.docker python3 manage.py runserver 0.0.0.0:8000

--- a/openstax/settings/docker.py
+++ b/openstax/settings/docker.py
@@ -1,0 +1,54 @@
+from .base import *
+
+# If local.py is present, any settings in it will override those in base.py and dev.py.
+# Use this for any settings that are specific to this one installation, such as developer API keys.
+# local.py should not be checked in to version control.
+
+EMBEDLY_KEY = 'get-one-from-http://embed.ly/'
+# GOOGLE_MAPS_KEY = 'get-one-from-https://code.google.com/apis/console/?noredirect'
+
+# It is strongly recommended that you define a SECRET_KEY here, where it won't be visible
+# in your version control system.
+SECRET_KEY = 'enter-a-long-unguessable-string-here'
+
+
+# When developing Wagtail templates, we recommend django-debug-toolbar
+# for keeping track of page rendering times. To use it:
+#     pip install django-debug-toolbar==1.0.1
+# and uncomment the lines below.
+
+# from .base import INSTALLED_APPS, MIDDLEWARE_CLASSES
+# INSTALLED_APPS += (
+#     'debug_toolbar',
+# )
+# MIDDLEWARE_CLASSES += (
+#     'debug_toolbar.middleware.DebugToolbarMiddleware',
+# )
+# # django-debug-toolbar settings
+# DEBUG_TOOLBAR_CONFIG = {
+#     'INTERCEPT_REDIRECTS': False,
+# }
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'NAME': 'postgres',
+        'USER': 'postgres',
+        'HOST': 'postgres',
+        'PASSWORD': 'password',
+        'PORT': 5432,
+    }
+}
+
+SALESFORCE = { 'username' : '',
+               'password' : '', # password might need to be concatinated with security_token e.g. 'mypass1231'
+               'security_token' : '',
+               'sandbox': True }
+
+# locally, we want to use local storage for uploaded files
+DEFAULT_FILE_STORAGE = 'django.core.files.storage.FileSystemStorage'
+
+# As of Django 1.10, we need to be explicit with localhost being allowed
+ALLOWED_HOSTS = ['127.0.0.1', 'localhost', '0.0.0.0']
+
+MAPBOX_TOKEN = '' # should be the sk from mapbox


### PR DESCRIPTION
I was trying to poke around with something on this app, but was unable to install the dependencies for it (got some lxml error with Python 3.7).  Instead of trying to fix my mac's environment, gave a shot at adding docker for local development, which is this PR.  @TomWoodward I started from your docker stuff on tutor-server.  I've never dockerized something before so I'd appreciate you taking a look and telling me where I'm a crazy man. 

Code is mounted in the container so you can develop on your local (host) machine, and Django auto reloads the changes.

Updated the README with how to use docker for the CMS.

cc @mwharrison  