### PR TITLE
Make trailing slashes optional without using redirects

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-slim
+FROM python:3.5-slim
 
 ENV PYTHONUNBUFFERED 1
 

--- a/books/tests.py
+++ b/books/tests.py
@@ -4,6 +4,7 @@ from pages.models import HomePage
 from books.models import BookIndex, Book, BookAllies
 #from snippets.models import Subject
 from allies.models import Ally
+from shared.test_utilities import assertPathDoesNotRedirectToTrailingSlash
 
 
 class BookTests(WagtailPageTests):
@@ -100,3 +101,8 @@ class BookTests(WagtailPageTests):
     def test_cannot_create_book_under_homepage(self):
         self.assertCanNotCreateAt(HomePage, Book)
 
+    def test_slashless_apis_are_good(self):
+        assertPathDoesNotRedirectToTrailingSlash(self, '/api/books')
+        assertPathDoesNotRedirectToTrailingSlash(self, '/apps/cms/api/books')
+        assertPathDoesNotRedirectToTrailingSlash(self, '/api/books/slug')
+        assertPathDoesNotRedirectToTrailingSlash(self, '/apps/cms/api/books/slug')

--- a/books/urls.py
+++ b/books/urls.py
@@ -2,6 +2,6 @@ from django.conf.urls import url
 from . import views
 
 urlpatterns = [
-    url(r'^$', views.book_index),
-    url(r'^(?P<slug>[\w-]+)/$', views.book_detail),
+    url(r'^/?$', views.book_index),
+    url(r'^/(?P<slug>[\w-]+)/?$', views.book_detail),
 ]

--- a/mail/tests.py
+++ b/mail/tests.py
@@ -29,8 +29,9 @@ class MailTest(TestCase):
                                                              'from_address': 'noreply@openstax.org',
                                                              'subject': 'Test Subject',
                                                              'message_body': 'This is a test.'})
+
         self.assertRedirects(
-            response, '/confirmation/contact', target_status_code=301)
+            response, '/confirmation/contact', target_status_code=301, fetch_redirect_response=False)
 
     def send_bulk_order_email(self):
         response = self.client.post('/api/mail/send_mail/', {'to_address': 'noreply@openstax.org',
@@ -39,7 +40,7 @@ class MailTest(TestCase):
                                                              'subject': 'Bulk Order',
                                                              'message_body': 'Send me a bulk order of books, please!'})
         self.assertRedirects(
-            response, '/confirmation/bulk-order', target_status_code=301)
+            response, '/confirmation/bulk-order', target_status_code=301, fetch_redirect_response=False)
 
     def test_send_redirect_report(self):
         redirects = self.create_fake_redirects()

--- a/mail/tests.py
+++ b/mail/tests.py
@@ -3,6 +3,7 @@ import mail.functions as mail_func
 
 from django.middleware import csrf
 from django.test import Client, TestCase
+from shared.test_utilities import assertPathDoesNotRedirectToTrailingSlash
 
 from mail.models import Mail
 
@@ -52,3 +53,7 @@ class MailTest(TestCase):
         redirect += '/l/refuse\thttps://openstax.org/openstax-tutor\n'
         redirect += '/r/trash\thttps://trello.com/b/20yf8veQ/devops-go\n'
         return redirect
+
+    def test_slashless_apis_are_good(self):
+        assertPathDoesNotRedirectToTrailingSlash(self, '/api/mail/send_mail')
+        assertPathDoesNotRedirectToTrailingSlash(self, '/apps/cms/api/mail/send_mail')

--- a/mail/urls.py
+++ b/mail/urls.py
@@ -3,5 +3,5 @@ from django.conf.urls import url
 from . import views
 
 urlpatterns = [
-    url(r'^send_mail/', views.send_contact_message),
+    url(r'^/send_mail/?', views.send_contact_message),
 ]

--- a/news/tests.py
+++ b/news/tests.py
@@ -1,0 +1,25 @@
+from wagtail.tests.utils import WagtailPageTests
+from shared.test_utilities import assertPathDoesNotRedirectToTrailingSlash
+from unittest.mock import MagicMock
+from .models import NewsIndex, NewsArticle, PressIndex, PressRelease
+
+class NewsTests(WagtailPageTests):
+    def setUp(self):
+        pass
+
+    def test_slashless_apis_are_good(self):
+        NewsIndex.objects.all = MagicMock(return_value=MagicMock(pk=3))
+        assertPathDoesNotRedirectToTrailingSlash(self, '/api/news')
+        assertPathDoesNotRedirectToTrailingSlash(self, '/apps/cms/api/news')
+
+        PressIndex.objects.all = MagicMock(return_value=MagicMock(pk=3))
+        assertPathDoesNotRedirectToTrailingSlash(self, '/api/press')
+        assertPathDoesNotRedirectToTrailingSlash(self, '/apps/cms/api/press')
+
+        NewsArticle.objects.get = MagicMock(return_value=MagicMock(pk=3))
+        assertPathDoesNotRedirectToTrailingSlash(self, '/api/news/slug')
+        assertPathDoesNotRedirectToTrailingSlash(self, '/apps/cms/api/news/slug')
+
+        PressRelease.objects.get = MagicMock(return_value=MagicMock(pk=3))
+        assertPathDoesNotRedirectToTrailingSlash(self, '/api/press/slug')
+        assertPathDoesNotRedirectToTrailingSlash(self, '/apps/cms/api/press/slug')

--- a/news/tests.py
+++ b/news/tests.py
@@ -1,7 +1,7 @@
 from wagtail.tests.utils import WagtailPageTests
 from shared.test_utilities import assertPathDoesNotRedirectToTrailingSlash
 from unittest.mock import MagicMock
-from .models import NewsIndex, NewsArticle, PressIndex, PressRelease
+from news.models import NewsIndex, NewsArticle, PressIndex, PressRelease
 
 class NewsTests(WagtailPageTests):
     def setUp(self):

--- a/news/urls.py
+++ b/news/urls.py
@@ -2,9 +2,9 @@ from django.conf.urls import url
 from . import views
 
 urlpatterns = [
-    url(r'^news/$', views.news_index),
-    url(r'^news/(?P<slug>[\w-]+)/$', views.news_detail),
+    url(r'^/news/?$', views.news_index),
+    url(r'^/news/(?P<slug>[\w-]+)/?$', views.news_detail),
 
-    url(r'^press/$', views.press_index),
-    url(r'^press/(?P<slug>[\w-]+)/$', views.press_detail),
+    url(r'^/press/?$', views.press_index),
+    url(r'^/press/(?P<slug>[\w-]+)/?$', views.press_detail),
 ]

--- a/openstax/settings/base.py
+++ b/openstax/settings/base.py
@@ -10,7 +10,16 @@ BASE_DIR = PROJECT_ROOT
 
 DEBUG = True
 
-APPEND_SLASH = False
+# Ideally, we'd never append a slash and have all of our URLs be able to work
+# with or without a slash.  However, some URLs are out of our control (e.g.
+# django admin URLs).  So we will leave the APPEND_SLASH setting to True, which
+# will append a slash if the incoming URL doesn't match any of our URL patterns.
+# (If it does match, it shouldn't append a slash, which is good and which means
+# we can work to make our URLs match either without or without slashes to avoid
+# extra redirects).  We disable for wagtail since it is its own self-contained
+# code.
+
+APPEND_SLASH = True
 WAGTAIL_APPEND_SLASH = False
 
 ADMINS = (

--- a/openstax/settings/base.py
+++ b/openstax/settings/base.py
@@ -11,6 +11,7 @@ BASE_DIR = PROJECT_ROOT
 DEBUG = True
 
 APPEND_SLASH = False
+WAGTAIL_APPEND_SLASH = False
 
 ADMINS = (
     ('Michael Harrison', 'mwharrison@rice.edu'),

--- a/openstax/settings/base.py
+++ b/openstax/settings/base.py
@@ -10,6 +10,8 @@ BASE_DIR = PROJECT_ROOT
 
 DEBUG = True
 
+APPEND_SLASH = False
+
 ADMINS = (
     ('Michael Harrison', 'mwharrison@rice.edu'),
 )

--- a/openstax/settings/base.py
+++ b/openstax/settings/base.py
@@ -22,6 +22,10 @@ DEBUG = True
 APPEND_SLASH = True
 WAGTAIL_APPEND_SLASH = False
 
+# urls.W002 warns about slashes at the start of URLs.  But we need those so
+#   we don't have to have slashes at the end of URLs.  So ignore.
+SILENCED_SYSTEM_CHECKS = ['urls.W002']
+
 ADMINS = (
     ('Michael Harrison', 'mwharrison@rice.edu'),
 )

--- a/openstax/urls.py
+++ b/openstax/urls.py
@@ -26,12 +26,12 @@ urlpatterns = [
     url(r'^django-admin/error/', throw_error, name='throw_error'),
 
     url(r'^accounts/', include('accounts.urls')),
-    url(r'^oxauth/', include('oxauth.urls')), # new auth package
+    url(r'^oxauth', include('oxauth.urls')), # new auth package
     url(r'^documents/', include(wagtaildocs_urls)),
     url(r'^images/', include(wagtailimages_urls)),
 
-    url(r'^api/mail/', include('mail.urls')),
-    url(r'^apps/cms/api/mail/', include('mail.urls')),
+    url(r'^api/mail', include('mail.urls')),
+    url(r'^apps/cms/api/mail', include('mail.urls')),
 
     url(r'^api/', include(api_urls)),
     url(r'^apps/cms/api/', include(api_urls)),
@@ -45,17 +45,17 @@ urlpatterns = [
     url(r'^api/salesforce/', include('salesforce.urls')),
     url(r'^apps/cms/api/salesforce/', include('salesforce.urls')),
 
-    url(r'^api/pages/', include('pages.urls')),
-    url(r'^apps/cms/api/pages/', include('pages.urls')),
+    url(r'^api/pages', include('pages.urls')),
+    url(r'^apps/cms/api/pages', include('pages.urls')),
 
     url(r'^api/snippets/', include('snippets.urls')),
     url(r'^apps/cms/api/snippets/', include('snippets.urls')),
 
-    url(r'^api/books/', include('books.urls')),
-    url(r'^apps/cms/api/books/', include('books.urls')),
+    url(r'^api/books', include('books.urls')),
+    url(r'^apps/cms/api/books', include('books.urls')),
 
-    url(r'^api/', include('news.urls')),
-    url(r'^apps/cms/api/', include('news.urls')),
+    url(r'^api', include('news.urls')),
+    url(r'^apps/cms/api', include('news.urls')),
 
     url(r'^blog-feed/rss/$', RssBlogFeed()),
     url(r'^blog-feed/atom/$', AtomBlogFeed()),

--- a/oxauth/urls.py
+++ b/oxauth/urls.py
@@ -2,7 +2,7 @@ from django.conf.urls import include, url
 from .views import login, logout, get_user_data
 
 urlpatterns = [
-    url(r'login', login, name='login'),
-    url(r'logout', logout, name='logout'),
-    url(r'user', get_user_data, name='user'),
+    url(r'^/login/?$', login, name='login'),
+    url(r'^/logout/?$', logout, name='logout'),
+    url(r'^/user/?$', get_user_data, name='user'),
 ]

--- a/pages/tests.py
+++ b/pages/tests.py
@@ -38,6 +38,7 @@ from pages.models import (HomePage,
 from allies.models import Ally
 from news.models import NewsIndex, PressIndex
 from books.models import BookIndex
+from shared.test_utilities import assertPathDoesNotRedirectToTrailingSlash
 
 
 class HomePageTests(WagtailPageTests):
@@ -110,6 +111,9 @@ class PageTests(WagtailPageTests):
             response = self.client.get('/api/pages/{}'.format(page.slug))
             self.assertNotEquals(response.status_code, 404)
 
+    def test_slashless_apis_are_good(self):
+        assertPathDoesNotRedirectToTrailingSlash(self, '/api/pages/slug')
+        assertPathDoesNotRedirectToTrailingSlash(self, '/apps/cms/api/pages/slug')
 
 
 class ErrataListTest(WagtailPageTests):

--- a/pages/urls.py
+++ b/pages/urls.py
@@ -2,5 +2,5 @@ from django.conf.urls import url
 from pages import views
 
 urlpatterns = [
-    url(r'^(?P<slug>[\w-]+)/$', views.page_detail),
+    url(r'^/(?P<slug>[\w-]+)/?$', views.page_detail),
 ]

--- a/shared/test_utilities.py
+++ b/shared/test_utilities.py
@@ -1,0 +1,13 @@
+from django.urls import resolve, Resolver404
+
+def assertPathDoesNotRedirectToTrailingSlash(test, path):
+    try:
+        resolve(path)
+    except Resolver404:
+        test.fail(f'The path {path} cannot be found')
+
+    response = test.client.get(path)
+
+    if (type(response).__name__ == 'HttpResponsePermanentRedirect' or
+       type(response).__name__ == 'HttpResponsePermanentRedirect'):
+       test.assertNotEqual(response.url, path + "/")

--- a/shared/test_utilities.py
+++ b/shared/test_utilities.py
@@ -4,7 +4,7 @@ def assertPathDoesNotRedirectToTrailingSlash(test, path):
     try:
         resolve(path)
     except Resolver404:
-        test.fail(f'The path {path} cannot be found')
+        test.fail('The path {} cannot be found'.format(path))
 
     response = test.client.get(path)
 

--- a/shared/tests.py
+++ b/shared/tests.py
@@ -1,0 +1,11 @@
+from wagtail.tests.utils import WagtailPageTests
+from shared.test_utilities import assertPathDoesNotRedirectToTrailingSlash
+from unittest.mock import MagicMock
+
+class WagtailTests(WagtailPageTests):
+    def setUp(self):
+        pass
+
+    def test_slashless_apis_are_good(self):
+        # Doesn't pass if WAGTAIL_APPEND_SLASH = False is not set
+        assertPathDoesNotRedirectToTrailingSlash(self, '/api/v2/pages/30')


### PR DESCRIPTION
While investigating adding OSWeb into the Unified Cloudfront distribution, I spent some time looking at the requests in the Network tab of the Chrome inspector.  I noticed that there were lots of 301 redirects to the original request path with a trailing slash added.  Of 93 requests made to load https://openstax.org, 21 were redirects of this form.  These requests mostly took 50-150ms each.  Some are likely prefetching of content, so maybe it isn't directly seen by users, but still these are requests we shouldn't have to make (network traffic we shouldn't be hoisting on the client's device).

Here's an example of one request:

1. Request made to `https://[some-os-web-domain]/apps/cms/api/books?format=json`
2. 301 redirects to `/apps/cms/api/books/?format=json` (trailing slash added)
3. 302 redirects to `/api/v2/pages/30` (wrapping Wagtail)
4. 301 redirects to to `/api/v2/pages/30/` (trailing slash added)
5. 200 response returns content.  

Two of these redirects are for adding the trailing slash.  I'm interested in finding ways around the Wagtail redirect as a separate discussion.

**This PR handles makes the trailing slash optional without requiring a redirect for a a number of URL categories (mail, news, oxauth, pages, books).  Specs are added for Books and Pages.**

Because this PR changes the value of the `APPEND_SLASH` Django setting from `True` to `False`, I'm guessing a lot of things are going to break until we expand optional slash behavior around to the rest of the baseline.

## TODO ##

* [ ] Discuss any reasons we shouldn't do this
* [ ] Need to handle more of the URLs.  I didn't handle all of the URLs b/c I didn't know how to deal with some of them (e.g. /api/images uses `router.register` and I didn't understand the implications there)
* [ ] Add specs like this PR has for Books and Pages to the other django folders.  
* [ ] Discuss if we can return Wagtail content directly without requiring the user to make another roundtrip request to `/api/v2/pages/XX`.