### PR TITLE
cache pip install on travis to speed up builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
 - '3.5'
+cache: pip
 addons:
   postgresql: '9.4'
 before_install:


### PR DESCRIPTION
Should save travis from doing pip install every time.  Build time before was 5-7 mins.

First run of travis (pip was not yet cached) was 6 mins 13 seconds.

Second run (pip was cached) was 4 mins 34 seconds.