### PR TITLE
Undo WAGTAIL_APPEND_SLASH=False

### DIFF
--- a/books/views.py
+++ b/books/views.py
@@ -7,13 +7,13 @@ from .models import BookIndex, Book
 @csrf_exempt
 def book_index(request):
     page = BookIndex.objects.all()[0]
-    return redirect('/api/v2/pages/{}'.format(page.pk))
+    return redirect('/api/v2/pages/{}/'.format(page.pk))
 
 
 @csrf_exempt
 def book_detail(request, slug):
     try:
         page = Book.objects.get(slug=slug)
-        return redirect('/api/v2/pages/{}'.format(page.pk))
+        return redirect('/api/v2/pages/{}/'.format(page.pk))
     except Book.DoesNotExist:
         raise Http404("Book does not exist.")

--- a/news/models.py
+++ b/news/models.py
@@ -90,7 +90,7 @@ class NewsIndex(Page):
         article_data = {}
         for article in articles:
             article_data['{}'.format(article.slug)] = {
-                'detail_url': '/api/v2/pages/{}'.format(article.pk),
+                'detail_url': '/api/v2/pages/{}/'.format(article.pk),
                 'date': article.date,
                 'heading': article.heading,
                 'subheading': article.subheading,
@@ -318,7 +318,7 @@ class PressIndex(Page):
         releases_data = {}
         for release in releases:
             releases_data['press/{}'.format(release.slug)] = {
-                'detail_url': '/api/v2/pages/{}'.format(release.pk),
+                'detail_url': '/api/v2/pages/{}/'.format(release.pk),
                 'date': release.date,
                 'heading': release.heading,
                 'excerpt': release.excerpt,

--- a/news/views.py
+++ b/news/views.py
@@ -7,20 +7,20 @@ from .models import NewsIndex, NewsArticle, PressIndex, PressRelease
 def news_index(request):
     page = NewsIndex.objects.all()[0]
     print(page)
-    return redirect('/api/v2/pages/{}'.format(page.pk))
+    return redirect('/api/v2/pages/{}/'.format(page.pk))
 
 
 @csrf_exempt
 def news_detail(request, slug):
     page = NewsArticle.objects.get(slug=slug)
-    return redirect('/api/v2/pages/{}'.format(page.pk))
+    return redirect('/api/v2/pages/{}/'.format(page.pk))
 
 @csrf_exempt
 def press_index(request):
     page = PressIndex.objects.all()[0]
-    return redirect('/api/v2/pages/{}'.format(page.pk))
+    return redirect('/api/v2/pages/{}/'.format(page.pk))
 
 @csrf_exempt
 def press_detail(request, slug):
     page = PressRelease.objects.get(slug=slug)
-    return redirect('/api/v2/pages/{}'.format(page.pk))
+    return redirect('/api/v2/pages/{}/'.format(page.pk))

--- a/openstax/settings/base.py
+++ b/openstax/settings/base.py
@@ -16,11 +16,11 @@ DEBUG = True
 # will append a slash if the incoming URL doesn't match any of our URL patterns.
 # (If it does match, it shouldn't append a slash, which is good and which means
 # we can work to make our URLs match either without or without slashes to avoid
-# extra redirects).  We disable for wagtail since it is its own self-contained
-# code.
+# extra redirects).  We tried to set WAGTAIL_APPEND_SLASH=False for wagtail but
+# it wasn't handling unslashed paths as it should have (maybe because we are
+# wrapping wagtail paths ourselves under /api?)
 
 APPEND_SLASH = True
-WAGTAIL_APPEND_SLASH = False
 
 # urls.W002 warns about slashes at the start of URLs.  But we need those so
 #   we don't have to have slashes at the end of URLs.  So ignore.

--- a/pages/views.py
+++ b/pages/views.py
@@ -11,6 +11,6 @@ def page_detail(request, slug):
     """
     try:
         page = Page.objects.filter(slug=slug).first()
-        return redirect('/api/v2/pages/{}'.format(page.pk))
+        return redirect('/api/v2/pages/{}/'.format(page.pk))
     except:
         return HttpResponse(status=404)

--- a/shared/tests.py
+++ b/shared/tests.py
@@ -6,6 +6,3 @@ class WagtailTests(WagtailPageTests):
     def setUp(self):
         pass
 
-    def test_slashless_apis_are_good(self):
-        # Doesn't pass if WAGTAIL_APPEND_SLASH = False is not set
-        assertPathDoesNotRedirectToTrailingSlash(self, '/api/v2/pages/30')


### PR DESCRIPTION
Setting `WAGTAIL_APPEND_SLASH=False` was supposed to allow wagtail endpoints to handle URLs without and without trailing slashes, but maybe because of how we were building our own `/api/...` endpoints using wagtail it wasn't working.

So we revert that part of https://github.com/openstax/openstax-cms/pull/753