### PR TITLE
change /accounts to /auth

### DIFF
--- a/openstax/urls.py
+++ b/openstax/urls.py
@@ -25,7 +25,7 @@ urlpatterns = [
     url(r'^admin/', include(wagtailadmin_urls)),
     url(r'^django-admin/error/', throw_error, name='throw_error'),
 
-    url(r'^accounts/', include('accounts.urls')),
+    url(r'^auth/', include('accounts.urls')),
     url(r'^oxauth', include('oxauth.urls')), # new auth package
     url(r'^documents/', include(wagtaildocs_urls)),
     url(r'^images/', include(wagtailimages_urls)),


### PR DESCRIPTION
I think changing the url for now to avoid collisions and identify where oauth is still getting used on the site is the best way to get this ported.