### PR TITLE
use cloudfront proxied accounts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && \
   libxml2-dev \
   libxslt1-dev \
   libz-dev \
+  libpq-dev \
   && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /code

--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -1,0 +1,12 @@
+from django.test import TestCase
+from django.test.utils import override_settings
+
+class AccountsTestCase(TestCase):
+
+    @override_settings(ACCOUNTS_SERVER_URL='https://fakeaccounts.org')
+    def test_accounts_redirects_to_accounts_server_url(self):
+        path = "/accounts/login?blah=whatever"
+        response = self.client.get(path)
+        self.assertRedirects(response,
+                             "https://fakeaccounts.org{}".format(path),
+                             fetch_redirect_response=False)

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -1,0 +1,6 @@
+from django.conf.urls import url
+from .views import accounts
+
+urlpatterns = [
+    url(r"^.*$", accounts),
+]

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -1,0 +1,11 @@
+from django.shortcuts import redirect
+from django.http import request
+from django.conf import settings
+
+def accounts(request):
+    # This will not be reached in deployed environments where Cloudfront is serving OSWeb,
+    # because Cloudfront proxies all `/accounts*` traffic straight to Accounts.  It is only
+    # for test and dev environments.
+
+    url = "{}{}".format(settings.ACCOUNTS_SERVER_URL, request.get_full_path())
+    return redirect(url)

--- a/openstax/settings/base.py
+++ b/openstax/settings/base.py
@@ -188,6 +188,7 @@ INSTALLED_APPS = [
     'import_export',
     'django_extensions',
     # custom
+    'accounts',
     'admin_templates',  # this overrides the admin templates
     'api',
     'pages',

--- a/openstax/urls.py
+++ b/openstax/urls.py
@@ -7,6 +7,7 @@ from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.core import urls as wagtail_urls
 from wagtail.documents import urls as wagtaildocs_urls
 from wagtail.images import urls as wagtailimages_urls
+from accounts import urls as accounts_urls
 
 from .api import api_router
 from news.search import search
@@ -27,6 +28,7 @@ urlpatterns = [
     url(r'^oxauth', include('oxauth.urls')), # new auth package
     url(r'^documents/', include(wagtaildocs_urls)),
     url(r'^images/', include(wagtailimages_urls)),
+    url(r'^accounts', include(accounts_urls)), # non-CloudFront Accounts redirects
 
     url(r'^apps/cms/api/mail', include('mail.urls')),
     url(r'^apps/cms/api/', include(api_urls)),

--- a/oxauth/tests.py
+++ b/oxauth/tests.py
@@ -13,13 +13,13 @@ from .auth import OXSessionDecryptor
 
 class AccountsTestCase(TestCase):
     def setUp(self):
-        self.token = get_token()
         self.client = Client()
 
     def test_accounts_contains_uuid(self):
+        token = get_token()
         url = settings.USERS_QUERY + urlencode({
             'q': 'id:{}'.format("2"),
-            'access_token': self.token['access_token']
+            'access_token': token['access_token']
         })
 
         with urlopen(url) as url:
@@ -46,12 +46,18 @@ class AccountsTestCase(TestCase):
 
     def test_login(self):
         response = self.client.get(reverse('login'))
-        self.assertNotEqual(response.status_code, 404)
-    
+        self.assertRedirects(response, "/accounts/login/", fetch_redirect_response=False)
+
+        response = self.client.get(reverse('login') + "?next=foo")
+        self.assertRedirects(response, "/accounts/login/?r=foo", fetch_redirect_response=False)
+
     def test_logout(self):
         response = self.client.get(reverse('logout'))
-        self.assertNotEqual(response.status_code, 404)
-    
+        self.assertRedirects(response, "/accounts/logout/", fetch_redirect_response=False)
+
+        response = self.client.get(reverse('logout') + "?next=foo")
+        self.assertRedirects(response, "/accounts/logout/?r=foo", fetch_redirect_response=False)
+
     def test_user_notloggedin(self):
         response = self.client.get(reverse('user'))
 

--- a/oxauth/urls.py
+++ b/oxauth/urls.py
@@ -6,5 +6,4 @@ urlpatterns = [
     url(r"^/login/?$", login, name="login"),
     url(r"^/logout/?$", logout, name="logout"),
     url(r"^/user/?$", get_user_data, name="user"),
-    url(r"^/accounts/?$", accounts, name="accounts"),
 ]

--- a/oxauth/urls.py
+++ b/oxauth/urls.py
@@ -6,4 +6,5 @@ urlpatterns = [
     url(r"^/login/?$", login, name="login"),
     url(r"^/logout/?$", logout, name="logout"),
     url(r"^/user/?$", get_user_data, name="user"),
+    url(r"^/accounts/?$", accounts, name="accounts"),
 ]

--- a/oxauth/views.py
+++ b/oxauth/views.py
@@ -47,11 +47,3 @@ def logout(request):
         url = "/accounts/logout/?r={}".format(next)
 
     return redirect(url)
-
-def accounts(request):
-    # This will not be reached in deployed environments where Cloudfront is serving OSWeb,
-    # because Cloudfront proxies all `/accounts*` traffic straight to Accounts.  It is only
-    # for test and dev environments where we have Accounts running.
-
-    url = "{}{}".format(settings.ACCOUNTS_SERVER_URL, request.get_full_path())
-    return redirect(url)

--- a/oxauth/views.py
+++ b/oxauth/views.py
@@ -7,11 +7,11 @@ from .auth import OXSessionDecryptor
 
 
 def login(request):
-    url = "{}login/".format(settings.ACCOUNTS_SERVER_URL)
+    url = "/accounts/login/"
 
     next = request.GET.get("next", None)
     if next:
-        url = "{}login/?r={}".format(settings.ACCOUNTS_SERVER_URL, next)
+        url = "/accounts/login/?r={}".format(next)
 
     return redirect(url)
 
@@ -28,7 +28,7 @@ def get_user_data(request):
     # TODO: Fix Validation. Currently, does not validate cookie unless the logged in user is id=1
     #if not validate:
     #    return JsonResponse({"logged_in": False, "cookie": True, "validation": False, "decryption": False})
-    
+
     decrypted_user = decrypt.get_cookie_data(cookie)
 
     if not decrypted_user:
@@ -40,10 +40,18 @@ def get_user_data(request):
         return JsonResponse(decrypted_user)
 
 def logout(request):
-    url = "{}logout/".format(settings.ACCOUNTS_SERVER_URL)
+    url = "/accounts/logout/"
 
     next = request.GET.get("next", None)
     if next:
-        url = "{}logout/?r={}".format(settings.ACCOUNTS_SERVER_URL, next)
+        url = "/accounts/logout/?r={}".format(next)
 
+    return redirect(url)
+
+def accounts(request):
+    # This will not be reached in deployed environments where Cloudfront is serving OSWeb,
+    # because Cloudfront proxies all `/accounts*` traffic straight to Accounts.  It is only
+    # for test and dev environments where we have Accounts running.
+
+    url = "{}{}".format(settings.ACCOUNTS_SERVER_URL, request.get_full_path())
     return redirect(url)


### PR DESCRIPTION
Instead of redirecting login and logout to a full Accounts URL, redirect to `/accounts/...`.  In a CloudFront deployment, such a redirect will be routed to the desired Accounts instance with the benefit that the URL in the browser will keep the same top-level domain, e.g. https://openstax.org/accounts/login.  In a local or test environment (which obviously doesn't have CloudFront), there is a new `accounts` action and URL to do the full domain redirect as was done previously.

This PR makes the Accounts URL behavior match that in REX.

## TODO

* [ ] specs

