### PR TITLE
Remove pulse insight feature flag.

### DIFF
--- a/openstax/settings/base.py
+++ b/openstax/settings/base.py
@@ -310,7 +310,6 @@ RAVEN_CONFIG = {
 # FLAGS
 FLAGS = {
     'hide_faculty_resources': [],
-    'disable_pulse_insights': [],
 }
 
 


### PR DESCRIPTION
This was not implemented on the FE - and to do so means modifying the PI code, which is a bad idea. So we're going to remove this to alliviate confusion.