### PR TITLE
removing detail field from read-only section for Editorial Vendors group

### DIFF
--- a/errata/admin.py
+++ b/errata/admin.py
@@ -208,7 +208,6 @@ class ErrataAdmin(ExportActionModelAdmin):
                                     'accounts_user_faculty_status',
                                     'archived',
                                     'junk',
-                                    'detail',
                                     ]
 
             self.save_as = True


### PR DESCRIPTION
this was preventing the detail field from being copied over when saving an erratum as a new one (copying it)