### PR TITLE
Set file usage flag to False

### DIFF
--- a/openstax/settings/base.py
+++ b/openstax/settings/base.py
@@ -308,7 +308,7 @@ WAGTAIL_SITE_NAME = 'openstax'
 # Wagtail API number of results
 WAGTAILAPI_LIMIT_MAX = None
 WAGTAILUSERS_PASSWORD_ENABLED = False
-WAGTAIL_USAGE_COUNT_ENABLED = True
+WAGTAIL_USAGE_COUNT_ENABLED = False
 
 # used in page.models to retrieve book information
 CNX_ARCHIVE_URL = 'https://archive.cnx.org'


### PR DESCRIPTION
The current count is not accurate. It is displaying zero for all files. While the cause of the zero count is not currently know, it was decided to turn the count display off because of an [issue in Wagtail](https://github.com/wagtail/wagtail/issues/1162) where StreamFields are not included in the count. Some of our documents and images are in StreamFields. We will revisit this once Wagtail has added StreamFields to the count.