### PR TITLE
invalidate cloudfront cache after errata save

### DIFF
--- a/errata/models.py
+++ b/errata/models.py
@@ -16,6 +16,7 @@ from wagtail.admin.menu import MenuItem
 from books.models import Book
 from django.conf import settings
 from oxauth.functions import get_user_info
+from global_settings.functions import invalidate_cloudfront_caches
 
 
 YES = 'Yes'
@@ -281,6 +282,9 @@ class Errata(models.Model):
         # set to archived if user is shadow banned
         if(is_user_shadow_blocked(self.submitted_by_account_id)):
             self.archived = True
+
+        # invalidate cloudfront cache so FE updates (remove when errata is no longer in CMS)
+        invalidate_cloudfront_caches()
 
         super(Errata, self).save(*args, **kwargs)
 

--- a/global_settings/functions.py
+++ b/global_settings/functions.py
@@ -21,5 +21,7 @@ def invalidate_cloudfront_caches():
         )
     except CloudfrontDistribution.DoesNotExist:
         return
+    except IndexError:
+        return
     except NoCredentialsError:
         print('No AWS credentials set - unable to invalidate cache')

--- a/global_settings/functions.py
+++ b/global_settings/functions.py
@@ -1,0 +1,25 @@
+import boto3
+from time import time
+from botocore.exceptions import NoCredentialsError
+from .models import CloudfrontDistribution
+
+def invalidate_cloudfront_caches():
+    try:
+        distribution = CloudfrontDistribution.objects.all()[0]
+        client = boto3.client('cloudfront')
+        response = client.create_invalidation(
+            DistributionId=distribution.distribution_id,
+            InvalidationBatch={
+                'Paths': {
+                    'Quantity': 1,
+                    'Items': [
+                        '/apps/cms/api/*' # invalidate the entire cache for the website
+                    ],
+                },
+                'CallerReference': str(time()).replace(".", "")
+            }
+        )
+    except CloudfrontDistribution.DoesNotExist:
+        return
+    except NoCredentialsError:
+        print('No AWS credentials set - unable to invalidate cache')


### PR DESCRIPTION
we were invalidating the cache after a page save - we also need to do it when a piece of errata is saved