### PR TITLE
move sentry configs to env settings

### DIFF
--- a/openstax/settings/base.py
+++ b/openstax/settings/base.py
@@ -338,14 +338,6 @@ AWS_HEADERS = {
 }
 
 
-import sentry_sdk
-from sentry_sdk.integrations.django import DjangoIntegration
-sentry_sdk.init(
-    dsn='https://2e1ecafc60684f86b59c654de3032d83:7fbc901dcca04dc4a8220f7cce20fdd9@sentry.cnx.org/11',
-    integrations=[DjangoIntegration()]
-)
-
-
 try:
     from local import *
 except ImportError:

--- a/openstax/settings/base.py
+++ b/openstax/settings/base.py
@@ -263,6 +263,10 @@ logging.config.dictConfig({
         'django.server': DEFAULT_LOGGING['formatters']['django.server'],
     },
     'handlers': {
+        #disable logs set with null handler
+        'null': {
+            'class': 'logging.NullHandler',
+        },
         # console logs to stderr
         'console': {
             'class': 'logging.StreamHandler',

--- a/openstax/settings/base.py
+++ b/openstax/settings/base.py
@@ -283,8 +283,7 @@ logging.config.dictConfig({
             'propagate': False,
         },
         'django.security.DisallowedHost': {
-            'level': 'ERROR',
-            'handlers': ['console'],
+            'handlers': ['null'],
             'propagate': False,
         },
         'django.request': {

--- a/openstax/settings/dev.py
+++ b/openstax/settings/dev.py
@@ -45,6 +45,13 @@ CNX_URL = 'https://dev.cnx.org/'
 SCOUT_MONITOR = True
 SCOUT_NAME = "openstax-cms (dev)"
 
+import sentry_sdk
+from sentry_sdk.integrations.django import DjangoIntegration
+sentry_sdk.init(
+    dsn='https://2e1ecafc60684f86b59c654de3032d83:7fbc901dcca04dc4a8220f7cce20fdd9@sentry.cnx.org/11',
+    integrations=[DjangoIntegration()]
+)
+
 try:
     from .local import *
 except ImportError:

--- a/openstax/settings/prod.py
+++ b/openstax/settings/prod.py
@@ -46,6 +46,13 @@ CNX_URL = 'https://cnx.org/'
 SCOUT_MONITOR = True
 SCOUT_NAME = "openstax-cms (prod)"
 
+import sentry_sdk
+from sentry_sdk.integrations.django import DjangoIntegration
+sentry_sdk.init(
+    dsn='https://2e1ecafc60684f86b59c654de3032d83:7fbc901dcca04dc4a8220f7cce20fdd9@sentry.cnx.org/11',
+    integrations=[DjangoIntegration()]
+)
+
 try:
     from .local import *
 except ImportError:

--- a/openstax/settings/qa.py
+++ b/openstax/settings/qa.py
@@ -38,6 +38,13 @@ CNX_URL = 'https://qa.cnx.org/'
 SCOUT_MONITOR = True
 SCOUT_NAME = "openstax-cms (qa)"
 
+import sentry_sdk
+from sentry_sdk.integrations.django import DjangoIntegration
+sentry_sdk.init(
+    dsn='https://2e1ecafc60684f86b59c654de3032d83:7fbc901dcca04dc4a8220f7cce20fdd9@sentry.cnx.org/11',
+    integrations=[DjangoIntegration()]
+)
+
 try:
     from .local import *
 except ImportError:

--- a/openstax/settings/staging.py
+++ b/openstax/settings/staging.py
@@ -46,6 +46,13 @@ CNX_URL = 'https://staging.cnx.org/'
 SCOUT_MONITOR = True
 SCOUT_NAME = "openstax-cms (staging)"
 
+import sentry_sdk
+from sentry_sdk.integrations.django import DjangoIntegration
+sentry_sdk.init(
+    dsn='https://2e1ecafc60684f86b59c654de3032d83:7fbc901dcca04dc4a8220f7cce20fdd9@sentry.cnx.org/11',
+    integrations=[DjangoIntegration()]
+)
+
 try:
     from .local import *
 except ImportError:


### PR DESCRIPTION
Local environments are currently reporting to Sentry. This is not useful and results in lots of local errors being reported. Moving them so they only work on dev/qa/staging/prod.