### PR TITLE
Removed errata links from sitemap

### DIFF
--- a/books/models.py
+++ b/books/models.py
@@ -929,10 +929,6 @@ class Book(Page):
             {
                 'location': '{}/details/books/{}'.format(Site.find_for_request(request).root_url, self.slug),
                 'lastmod': (self.last_published_at or self.latest_revision_created_at),
-            },
-            {
-                'location': '{}/errata/?book={}'.format(Site.find_for_request(request).root_url, self.title),
-                'lastmod': (self.last_published_at or self.latest_revision_created_at),
             }
         ]
 


### PR DESCRIPTION
Google is complaining that errata is in the sitemap and we recently blocked it in robots.txt.