### PR TITLE
Upgrade wand package

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -105,7 +105,7 @@ psutil==5.6.3
 scout-apm==2.14.3
 
 # for supporting animated gifs
-Wand==0.6.5
+Wand==0.6.6
 
 # for recording test interactions with third-party APIs
 vcrpy==4.1.1


### PR DESCRIPTION
Getting some errors on images with GIFs. This is the ImageMagik python bindings - some Github issues appeared to fix the issue by upgrading. 