### PR TITLE
add feature flag for my openstax

### DIFF
--- a/openstax/settings/base.py
+++ b/openstax/settings/base.py
@@ -313,7 +313,7 @@ logging.config.dictConfig({
 
 # FLAGS
 FLAGS = {
-    'hide_faculty_resources': [],
+    'enable_my_openstax': [],
 }
 
 


### PR DESCRIPTION
@RoyEJohnson you can query for this flag here: /apps/cms/api/flags?flag=enable_my_openstax
It will return a value of True (show the my openstax links and such) or False (don't).

Feature flags can be modified in the admin, here: http://dev.openstax.org/django-admin/flags/flagstate/

This can be modified if you think it'd work better some other way - just let me know!