### PR TITLE
Use same errata content snippet for all Spanish books

### DIFF
--- a/books/models.py
+++ b/books/models.py
@@ -810,6 +810,8 @@ class Book(Page):
 
     @property
     def errata_content(self):
+        if self.locale == 'es':
+            return snippets.ErrataContent.objects.filter(locale=self.locale).first().content
         return snippets.ErrataContent.objects.filter(book_state=self.book_state, locale=self.locale).first().content
 
     def get_slug(self):


### PR DESCRIPTION

-  There should be only one Spanish Errata Content snippet in the CMS. The selected book state does not matter.
-  All Spanish books will display the one Spanish Errata Content text
-  English books will have a different Errata Content snippets based on book state.
