### PR TITLE
Update partner fields based on locale

### DIFF
--- a/books/models.py
+++ b/books/models.py
@@ -834,22 +834,22 @@ class Book(Page):
             self.webview_link = '{}contents/{}'.format(settings.CNX_URL, self.cnx_id)
 
         if self.partner_list_label:
-            Book.objects.all().update(partner_list_label=self.partner_list_label)
+            Book.objects.filter(locale=self.locale).update(partner_list_label=self.partner_list_label)
 
         if self.partner_page_link_text:
-            Book.objects.all().update(partner_page_link_text=self.partner_page_link_text)
+            Book.objects.filter(locale=self.locale).update(partner_page_link_text=self.partner_page_link_text)
 
         # sync customization form changes on all books
         if self.customization_form_heading:
-            Book.objects.all().update(customization_form_heading=self.customization_form_heading)
+            Book.objects.filter(locale=self.locale).update(customization_form_heading=self.customization_form_heading)
         if self.customization_form_subheading:
-            Book.objects.all().update(customization_form_subheading=self.customization_form_subheading)
+            Book.objects.filter(locale=self.locale).update(customization_form_subheading=self.customization_form_subheading)
         if self.customization_form_disclaimer:
-            Book.objects.all().update(customization_form_disclaimer=self.customization_form_disclaimer)
+            Book.objects.filter(locale=self.locale).update(customization_form_disclaimer=self.customization_form_disclaimer)
         if self.customization_form_next_steps:
-            Book.objects.all().update(customization_form_next_steps=self.customization_form_next_steps)
+            Book.objects.filter(locale=self.locale).update(customization_form_next_steps=self.customization_form_next_steps)
         if self.support_statement:
-            Book.objects.all().update(support_statement=self.support_statement)
+            Book.objects.filter(locale=self.locale).update(support_statement=self.support_statement)
 
         return super(Book, self).save(*args, **kwargs)
 

--- a/books/tests.py
+++ b/books/tests.py
@@ -41,6 +41,7 @@ class BookTests(WagtailPageTests):
 
     def test_can_create_book(self):
         book_index = BookIndex.objects.all()[0]
+        root_page = Page.objects.get(title="Root")
         book = Book(title="University Physics",
                     slug="university-physics",
                     cnx_id='031da8d3-b525-429c-80cf-6c8ed997733a',
@@ -50,12 +51,14 @@ class BookTests(WagtailPageTests):
                     cover=self.test_doc,
                     title_image=self.test_doc,
                     publish_date=datetime.date.today(),
+                    locale=root_page.locale
                     )
         book_index.add_child(instance=book)
         self.assertEqual(book.salesforce_abbreviation, 'University Phys (Calc)')
 
     def test_can_create_ap_book(self):
         book_index = BookIndex.objects.all()[0]
+        root_page = Page.objects.get(title="Root")
         book = Book(title="Prealgebra",
                     slug="prealgebra",
                     salesforce_abbreviation='Prealgebra',
@@ -65,6 +68,7 @@ class BookTests(WagtailPageTests):
                     cover=self.test_doc,
                     title_image=self.test_doc,
                     publish_date=datetime.date.today(),
+                    locale=root_page.locale
                     )
         book_index.add_child(instance=book)
         self.assertEqual(book.salesforce_abbreviation, 'Prealgebra')
@@ -72,6 +76,7 @@ class BookTests(WagtailPageTests):
 
     def test_can_create_book_without_cnx_id(self):
         book_index = BookIndex.objects.all()[0]
+        root_page = Page.objects.get(title="Root")
         book = Book(title="Prealgebra",
                     slug="prealgebra",
                     salesforce_abbreviation='Prealgebra',
@@ -80,12 +85,14 @@ class BookTests(WagtailPageTests):
                     cover=self.test_doc,
                     title_image=self.test_doc,
                     publish_date=datetime.date.today(),
+                    locale=root_page.locale
                     )
         book_index.add_child(instance=book)
         self.assertEqual(book.salesforce_abbreviation, 'Prealgebra')
 
     def test_only_numbers_for_price(self):
         book_index = BookIndex.objects.all()[0]
+        root_page = Page.objects.get(title="Root")
         book = Book(title="Prealgebra",
                 slug="prealgebra",
                 salesforce_abbreviation='Prealgebra',
@@ -94,6 +101,7 @@ class BookTests(WagtailPageTests):
                 cover=self.test_doc,
                 title_image=self.test_doc,
                 publish_date=datetime.date.today(),
+                locale=root_page.locale
                 )
         book_index.add_child(instance=book)
         self.assertEqual(book.salesforce_abbreviation, 'Prealgebra')

--- a/errata/tests.py
+++ b/errata/tests.py
@@ -40,6 +40,7 @@ class ErrataTest(TestCase):
                             cover=test_doc,
                             title_image=test_doc,
                             publish_date=datetime.date.today(),
+                            locale=root_page.locale
                             )
         book_index.add_child(instance=book)
 


### PR DESCRIPTION
If an English book fields are edited, all of the English books will get updated.  Same for Spanish. They should not mix.