### PR TITLE
Fixed bad logic and removed print stmt from test

### DIFF
--- a/api/tests.py
+++ b/api/tests.py
@@ -147,7 +147,6 @@ class APITests(TestCase, WagtailTestUtils):
 
     def test_errata_resource_api(self):
         response = self.client.get('/apps/cms/api/errata-fields?field=resources')
-        print('***Resources: ' + str(response.content))
         self.assertNotIn('content', 'OpenStax Concept Coach')
         self.assertNotIn('content', 'Rover by OpenStax')
         self.assertEqual(response.status_code, 200)

--- a/api/views.py
+++ b/api/views.py
@@ -100,7 +100,7 @@ def errata_fields(request):
     if request.GET.get('field', None) == 'resources':
         for field, verbose in ERRATA_RESOURCES:
             # This is not my favorite way to do this but we need to keep the data on existing errata
-            if field != 'OpenStax Concept Coach' or field != 'Rover by OpenStax':
+            if field != 'OpenStax Concept Coach' and field != 'Rover by OpenStax':
                 response.append({'field': field, 'verbose': verbose})
 
     return JsonResponse(response, safe=False)


### PR DESCRIPTION
Switched back to using `and`. Using `or` was causing both options to remain displayed.