### PR TITLE
Filter successful /ping requests from Django logs

### DIFF
--- a/healthcheck/filter.py
+++ b/healthcheck/filter.py
@@ -1,0 +1,9 @@
+from logging import Filter
+
+class HealthCheckFilter(Filter):
+    def filter(self, record):
+        # Should return True for all requests except successful healthcheck requests
+        return record.status_code != 204 or not (
+            record.args[0].startswith('GET /ping ') or
+            record.args[0].startswith('GET /ping/')
+        )

--- a/openstax/settings/base.py
+++ b/openstax/settings/base.py
@@ -292,6 +292,11 @@ LOGLEVEL = os.environ.get('LOGLEVEL', 'error').upper()
 logging.config.dictConfig({
     'version': 1,
     'disable_existing_loggers': False,
+    'filters': {
+        'healthcheck_filter': {
+            '()': 'healthcheck.filter.HealthCheckFilter'
+        },
+    },
     'formatters': {
         'default': {
             # exact format is not important, this is the minimum information
@@ -300,7 +305,7 @@ logging.config.dictConfig({
         'django.server': DEFAULT_LOGGING['formatters']['django.server'],
     },
     'handlers': {
-        #disable logs set with null handler
+        # disable logs set with null handler
         'null': {
             'class': 'logging.NullHandler',
         },
@@ -309,7 +314,10 @@ logging.config.dictConfig({
             'class': 'logging.StreamHandler',
             'formatter': 'default',
         },
-        'django.server': DEFAULT_LOGGING['handlers']['django.server'],
+        'django.server': {
+            **DEFAULT_LOGGING['handlers']['django.server'],
+            'filters': ['healthcheck_filter']
+        },
     },
     'loggers': {
         # default for all undefined Python modules


### PR DESCRIPTION
To reduce log spam, since this path is called every 5 seconds by the ELB