### PR TITLE
use django auth for login

### DIFF
--- a/openstax/settings/base.py
+++ b/openstax/settings/base.py
@@ -149,8 +149,8 @@ MIDDLEWARE = [
 ]
 
 AUTHENTICATION_BACKENDS = (
-    'oxauth.backend.OpenStaxAccountsBackend',
     'django.contrib.auth.backends.ModelBackend',
+    'oxauth.backend.OpenStaxAccountsBackend',
 )
 
 TEMPLATES = [
@@ -384,10 +384,8 @@ HOST_LINK = os.getenv('HOST_LINK', BASE_URL)
 # WAGTAIL SETTINGS
 WAGTAIL_SITE_NAME = 'openstax'
 WAGTAILAPI_BASE_URL = os.getenv('WAGTAILAPI_BASE_URL', BASE_URL)
-WAGTAIL_FRONTEND_LOGIN_URL = 'oxauth/login'
 # Wagtail API number of results
 WAGTAILAPI_LIMIT_MAX = None
-WAGTAILUSERS_PASSWORD_ENABLED = False
 WAGTAIL_USAGE_COUNT_ENABLED = False
 WAGTAIL_USER_CUSTOM_FIELDS = ['is_staff']
 WAGTAIL_GRAVATAR_PROVIDER_URL = '//www.gravatar.com/avatar'

--- a/openstax/urls.py
+++ b/openstax/urls.py
@@ -21,8 +21,8 @@ from wagtail.contrib.sitemaps.views import sitemap
 admin.site.site_header = 'OpenStax'
 
 urlpatterns = [
-    path('admin/login/', oxauth_views.login),
-    path('admin/logout/', oxauth_views.logout),
+    #path('admin/login/', oxauth_views.login),
+    #path('admin/logout/', oxauth_views.logout),
     path('oxauth/', include('oxauth.urls')), # new auth package
     path('admin/', include(wagtailadmin_urls)),
 


### PR DESCRIPTION
I think we are somewhat overcomplicating things by using accounts to login to the Django admin since we have so few people accessing it. 
The auth code is still there - so when we add more fine grained permissions into accounts we can reimplement this but for now, let's just use the django auth mechanism for logging into the admin.