### PR TITLE
Added django-dbbackup to install

### DIFF
--- a/backup/README.md
+++ b/backup/README.md
@@ -1,0 +1,11 @@
+## Using DBBackup
+
+ * Backups will be stored in this directory
+ * To create a database backup run `python manage.py dbbackup`
+
+## Copying backup to a different location
+
+ * Log into the AWS CLI
+ * run this command from bit-deployment
+   * `bin/scp cms dev cron :~/www/cms/backup/[backup file name] ~/new/location`
+   * Read more setup details in the scp file in bit-deployment

--- a/backup/README.md
+++ b/backup/README.md
@@ -9,3 +9,5 @@
  * run this command from bit-deployment
    * `bin/scp cms dev cron :~/www/cms/backup/[backup file name] ~/new/location`
    * Read more setup details in the scp file in bit-deployment
+
+[DBBackup Documentation](https://django-dbbackup.readthedocs.io/en/master/index.html)

--- a/openstax/settings/base.py
+++ b/openstax/settings/base.py
@@ -188,6 +188,7 @@ INSTALLED_APPS = [
     'django.contrib.postgres',
     'django.contrib.admin',
     'django.contrib.sitemaps',
+    'dbbackup',  # django-dbbackup
     # contrib
     'compressor',
     'taggit',
@@ -434,6 +435,10 @@ EVENTBRITE_API_KEY = os.getenv('EVENTBRITE_API_KEY', '')
 EVENTBRITE_API_SECRET = os.getenv('EVENTBRITE_API_SECRET', '')
 EVENTBRITE_API_PRIVATE_TOKEN = os.getenv('EVENTBRITE_API_PRIVATE_TOKEN', '')
 EVENTBRITE_API_PUBLIC_TOKEN = os.getenv('EVENTBRITE_API_PUBLIC_TOKEN', '')
+
+# djago-dbbackup
+DBBACKUP_STORAGE = 'django.core.files.storage.FileSystemStorage'
+DBBACKUP_STORAGE_OPTIONS = {'location': 'backup/'}
 
 # to override any of the above settings use a local.py file in this directory
 try:

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,6 +8,7 @@ django-rest-auth==0.9.5
 django-reversion==5.0.0
 django-ses==3.0.1
 django-storages==1.12.3
+django-dbbackup==4.0.2
 future==0.18.2
 html2text==2020.1.16 # used in news feed
 jsonfield==3.1.0


### PR DESCRIPTION
[Documentation](https://django-dbbackup.readthedocs.io/en/master/installation.html) for DBBackup

Can be used to create a database backup file that can be copied using bit-deployment to another location.