### PR TITLE
K12 sitemap fix

### DIFF
--- a/news/search.py
+++ b/news/search.py
@@ -63,7 +63,7 @@ def search(request):
         found_entries = NewsArticle.objects.annotate(
             rank=SearchRank(vector, query),
             search=vector,
-        ).filter(rank__gte=0.3).order_by('-date', 'rank')
+        ).filter(rank__gte=0.3,live=True).order_by('-date', 'rank')
 
     if ('collection' in request.GET) and request.GET['collection'].strip():
         collection_name = request.GET['collection']

--- a/pages/models.py
+++ b/pages/models.py
@@ -9,6 +9,7 @@ from wagtail.models import Orderable, Page
 from wagtail.api import APIField
 from wagtail.models import Site
 
+from api.models import FeatureFlag
 from openstax.functions import build_image_url, build_document_url
 from books.models import Book, SubjectBooks, BookFacultyResources, BookStudentResources
 from webinars.models import Webinar
@@ -758,20 +759,6 @@ class GeneralPage(Page):
                     'lastmod': (self.last_published_at or self.latest_revision_created_at),
                 }
             ]
-        # elif self.slug == 'write-for-us':
-        #     return [
-        #         {
-        #             'location': '{}/{}'.format(Site.find_for_request(request).root_url, self.slug),
-        #             'lastmod': (self.last_published_at or self.latest_revision_created_at),
-        #         }
-        #     ]
-        # elif self.slug == 'editorial-calendar':
-        #     return [
-        #         {
-        #             'location': '{}/{}'.format(Site.find_for_request(request).root_url, self.slug),
-        #             'lastmod': (self.last_published_at or self.latest_revision_created_at),
-        #         }
-        #     ]
         else:
             return []
 
@@ -2597,6 +2584,18 @@ class Subjects(Page):
 
         return subject_list
 
+    def get_sitemap_urls(self, request=None):
+        flag = FeatureFlag.objects.filter(name='new_subjects')
+        if flag[0].feature_active:
+            return [
+                {
+                    'location': '{}/subjects'.format(Site.find_for_request(request).root_url),
+                    'lastmod': (self.last_published_at or self.latest_revision_created_at),
+                }
+            ]
+        else:
+            return []
+
     api_fields = [
         APIField('heading'),
         APIField('description'),
@@ -2710,12 +2709,16 @@ class Subject(Page):
     )
 
     def get_sitemap_urls(self, request=None):
-        return [
-            {
-                'location': '{}/subjects/{}'.format(Site.find_for_request(request).root_url, self.slug),
-                'lastmod': (self.last_published_at or self.latest_revision_created_at),
-            }
-        ]
+        flag = FeatureFlag.objects.filter(name='new_subjects')
+        if flag[0].feature_active:
+            return [
+                {
+                    'location': '{}/subjects/{}'.format(Site.find_for_request(request).root_url, self.slug),
+                    'lastmod': (self.last_published_at or self.latest_revision_created_at),
+                }
+            ]
+        else:
+            return []
 
     @property
     def selected_subject(self):

--- a/pages/models.py
+++ b/pages/models.py
@@ -581,7 +581,7 @@ class K12MainPage(Page):
     def get_sitemap_urls(self, request=None):
         return [
             {
-                'location': '{}/k12/{}'.format(Site.find_for_request(request).root_url, self.slug[4:]),
+                'location': '{}/k12'.format(Site.find_for_request(request).root_url),
                 'lastmod': (self.last_published_at or self.latest_revision_created_at),
             }
         ]
@@ -2583,14 +2583,6 @@ class Subjects(Page):
         related_name='+'
     )
 
-    def get_sitemap_urls(self, request=None):
-        return [
-            {
-                'location': '{}/subjects/{}'.format(Site.find_for_request(request).root_url, self.slug),
-                'lastmod': (self.last_published_at or self.latest_revision_created_at),
-            }
-        ]
-
     @property
     def subjects(self):
         subject_list = {}
@@ -2716,6 +2708,14 @@ class Subject(Page):
         on_delete=models.SET_NULL,
         related_name='+'
     )
+
+    def get_sitemap_urls(self, request=None):
+        return [
+            {
+                'location': '{}/subjects/{}'.format(Site.find_for_request(request).root_url, self.slug),
+                'lastmod': (self.last_published_at or self.latest_revision_created_at),
+            }
+        ]
 
     @property
     def selected_subject(self):
@@ -3024,6 +3024,14 @@ class K12Subject(Page):
                 'resource_category': resource.resource_category,
                 })
         return faculty_resource_data
+
+    def get_sitemap_urls(self, request=None):
+        return [
+            {
+                'location': '{}/k12/{}'.format(Site.find_for_request(request).root_url, self.slug[4:]),
+                'lastmod': (self.last_published_at or self.latest_revision_created_at),
+            }
+        ]
 
     api_fields = [
         APIField('subheader'),

--- a/pages/models.py
+++ b/pages/models.py
@@ -581,7 +581,7 @@ class K12MainPage(Page):
     def get_sitemap_urls(self, request=None):
         return [
             {
-                'location': '{}/k12/{}'.format(Site.find_for_request(request).root_url, self.slug),
+                'location': '{}/k12/{}'.format(Site.find_for_request(request).root_url, self.slug[4:]),
                 'lastmod': (self.last_published_at or self.latest_revision_created_at),
             }
         ]
@@ -2582,6 +2582,14 @@ class Subjects(Page):
         on_delete=models.SET_NULL,
         related_name='+'
     )
+
+    def get_sitemap_urls(self, request=None):
+        return [
+            {
+                'location': '{}/subjects/{}'.format(Site.find_for_request(request).root_url, self.slug),
+                'lastmod': (self.last_published_at or self.latest_revision_created_at),
+            }
+        ]
 
     @property
     def subjects(self):

--- a/pages/templates/page.html
+++ b/pages/templates/page.html
@@ -5,21 +5,21 @@
 <html>
 <head>
 
-    <title>{{ page.seo_title }}</title>
+    <title>{{ page.title }}</title>
     <meta name="description" content="{{ page.search_description }}">
     <link rel="canonical" href="{{page.get_full_url}}" />
     <meta http-equiv="refresh">
 
     <meta property="og:url" content="{{page.get_full_url}}" />
     <meta property="og:type" content="article" />
-    <meta property="og:title" content="{{ page.seo_title }}" />
+    <meta property="og:title" content="{{ page.title }}" />
     <meta property="og:description" content="{{ page.search_description }}" />
     <meta property="og:image" content="{{ promote_image.url }}" />
-    <meta property="og:image:alt" content="OpenStax: {{ page.seo_title }}" />
+    <meta property="og:image:alt" content="OpenStax: {{ page.title }}" />
 
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:site" content="@OpenStax">
-    <meta name="twitter:title" content="{{ page.seo_title }}">
+    <meta name="twitter:title" content="{{ page.title }}">
     <meta name="twitter:description" content="{{ page.search_description }}">
     <meta name="twitter:image" content="{{ promote_image.url }}">
     <meta name="twitter:image:alt" content="OpenStax">

--- a/pages/tests.py
+++ b/pages/tests.py
@@ -1,3 +1,5 @@
+import json
+
 from django.test import TestCase, Client
 from django.core.management import call_command
 from wagtail.test.utils import WagtailTestUtils, WagtailPageTests
@@ -174,6 +176,36 @@ class PageTests(WagtailPageTests):
 
         retrieved_page = Page.objects.get(id=k12_page.id)
         self.assertEqual(retrieved_page.title, "K12 Main Page")
+
+    def test_can_create_contact_us_page(self):
+        contact_us_page = ContactUs(title='Contact Us',
+                               tagline='this is a tagline',
+                               mailing_header='Mailing header',
+                               mailing_address='123 Street, East SomeTown, Tx',
+                               customer_service='How can I help you?',
+        )
+        self.homepage.add_child(instance=contact_us_page)
+        self.assertCanCreateAt(HomePage, ContactUs)
+
+        retrieved_page = Page.objects.get(id=contact_us_page.id)
+        self.assertEqual(retrieved_page.title, "Contact Us")
+
+    def test_can_create_general_page(self):
+        general_page = GeneralPage(title='General Page',
+                               body=json.dumps(
+                                   [{"id": "ae6f048b-6eb5-42e7-844f-cfcd459f81b5", "type": "heading",
+                                     "value": "General Page"},
+                                    {"id": "a21bcbd4-fec4-432e-bf06-966d739c6de9", "type": "paragraph",
+                                     "value": "<p data-block-key=\"wr6bg\">This is a test of a general page.</p><p data-block-key=\"d57h\">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>"},
+                                    {"id": "4d339739-131c-4547-954b-0787afdc4914", "type": "tagline",
+                                     "value": "This is a test"}]
+                               ),
+        )
+        self.homepage.add_child(instance=general_page)
+        self.assertCanCreateAt(HomePage, GeneralPage)
+
+        retrieved_page = Page.objects.get(id=general_page.id)
+        self.assertEqual(retrieved_page.title, "General Page")
 
 
 class ErrataListTest(WagtailPageTests):


### PR DESCRIPTION
* new subjects pages are added to sitemap if feature flag is on
* K12 pages are now correctly added to the sitemap
* Link preview for k12 works
* Link preview for new subjects page looks at feature flag to determine if the URL is old or new subjects page
* Added 2 tests for pages
* Added blog search fix in earlier release