### PR TITLE
force specific platform only on the Docker app container (fix for Mac M1)

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,6 +1,7 @@
 version: '3.5'
 services:
   app:
+    platform: linux/amd64
     build: .
     ports:
       - "8000:8000"


### PR DESCRIPTION
[According to Colby](https://openstax.slack.com/archives/C0LA54Q5C/p1692813178119899?thread_ts=1692811204.056329&cid=C0LA54Q5C) this works (I have no way to test it and GH actions still [does not support ARM on their CI](https://github.com/actions/runner-images/issues/5631)):

![image](https://github.com/openstax/openstax-cms/assets/1050582/ac14c798-910a-4b89-b9c6-ef097b73face)

Problem on Mac M1:
* The application docker container fails on gcc compilation step on Mac M1/M2 laptops on build.
* When forcing whole docker compose to use AMD64 architecture, the Postgres container will not work in daemon mode. So Wagtail cannot be started.

Solution is to run both containers in a mixed architecture on ARM:
* Force AMD64 architecture on the application container (will be emulated internally on Docker with QEMU)
* and let Postgres container run in the architecture in which the docker host is running (ARM or AMD64)
