### PR TITLE
use query_all to get all records

### DIFF
--- a/openstax/settings/base.py
+++ b/openstax/settings/base.py
@@ -259,7 +259,7 @@ CRONJOBS = [
     ('0 2 * * *', 'django.core.management.call_command', ['delete_resource_downloads']),
     ('0 6 * * *', 'django.core.management.call_command', ['update_resource_downloads']),
     ('0 0 8 * *', 'django.core.management.call_command', ['update_schools_and_mapbox']),
-    # ('0 0 1 * *', 'django.core.management.call_command', ['update_opportunities']),
+    ('0 0 * * *', 'django.core.management.call_command', ['update_opportunities']),
     ('0 10 * * *', 'django.core.management.call_command', ['update_partners']),
 ]
 

--- a/salesforce/management/commands/update_opportunities.py
+++ b/salesforce/management/commands/update_opportunities.py
@@ -45,6 +45,7 @@ class Command(BaseCommand):
             response = sf.query_all(query)
             records = response['records']
 
+            # TODO: this doesn't need to be updating on the opp id, the info never changes
             for record in records:
                 opportunity, created = AdoptionOpportunityRecord.objects.update_or_create(
                     opportunity_id=record['Id'],
@@ -61,3 +62,6 @@ class Command(BaseCommand):
                               }
                 )
                 opportunity.save()
+
+                # TODO: need to grab current adoptions and if the info has changed, update it so the user sees most recent adoption info
+                # re-submitting the form will update the current year adoption numbers, which the user might not expect

--- a/salesforce/management/commands/update_opportunities.py
+++ b/salesforce/management/commands/update_opportunities.py
@@ -1,4 +1,5 @@
 import datetime
+import uuid
 from django.core.management.base import BaseCommand
 from salesforce.models import AdoptionOpportunityRecord
 from salesforce.salesforce import Salesforce
@@ -47,7 +48,7 @@ class Command(BaseCommand):
             for record in records:
                 opportunity, created = AdoptionOpportunityRecord.objects.update_or_create(
                     opportunity_id=record['Id'],
-                    defaults={'account_uuid': record['Opportunity__r']['Contact__r']['Accounts_UUID__c'],
+                    defaults={'account_uuid': uuid.UUID(record['Opportunity__r']['Contact__r']['Accounts_UUID__c']),
                               'opportunity_stage': record['Opportunity__r']['StageName'],
                               'adoption_type': record['Adoption_Type__c'],
                               'base_year': record['Base_Year__c'],

--- a/salesforce/management/commands/update_opportunities.py
+++ b/salesforce/management/commands/update_opportunities.py
@@ -41,15 +41,15 @@ class Command(BaseCommand):
                      "AND Opportunity__r.Contact__r.Adoption_Status__c != 'Current Adopter'").format(base_year)
 
             # This generally returns more than 2,000 records (the SF limit)
-            # See simplate_salesforce documentation for query_all: https://github.com/simple-salesforce/simple-salesforce?tab=readme-ov-file#queries
-            response = sf.query_all(query)
-            records = response['records']
+            # See simplate_salesforce documentation for query_all: https://github.com/simple-salesforce/simple-salesforce?tab=readme-ov-file#using-bulk
+            results = sf.bulk.Adoption__c.query(query)
 
             # TODO: this doesn't need to be updating on the opp id, the info never changes
-            for record in records:
+            for i, record in enumerate(results):
                 opportunity, created = AdoptionOpportunityRecord.objects.update_or_create(
-                    opportunity_id=record['Id'],
-                    defaults={'account_uuid': uuid.UUID(record['Opportunity__r']['Contact__r']['Accounts_UUID__c']),
+                    account_uuid=uuid.UUID(record['Opportunity__r']['Contact__r']['Accounts_UUID__c']),
+                    book_name=record['Opportunity__r']['Book__r']['Name'],
+                    defaults={'opportunity_id': record['Id'],
                               'opportunity_stage': record['Opportunity__r']['StageName'],
                               'adoption_type': record['Adoption_Type__c'],
                               'base_year': record['Base_Year__c'],
@@ -57,8 +57,7 @@ class Command(BaseCommand):
                               'confirmation_type': record['Confirmation_Type__c'],
                               'how_using': record['How_Using__c'],
                               'savings': record['Savings__c'],
-                              'students': record['Students__c'],
-                              'book_name': record['Opportunity__r']['Book__r']['Name'],
+                              'students': record['Students__c']
                               }
                 )
                 opportunity.save()

--- a/salesforce/management/commands/update_opportunities.py
+++ b/salesforce/management/commands/update_opportunities.py
@@ -64,6 +64,8 @@ class Command(BaseCommand):
                     opportunity.save()
                 except ValueError:
                     sentry_sdk.capture_message("Adoption {} has a badly formatted Account UUID: {}".format(record['Id'], record['Opportunity__r']['Contact__r']['Accounts_UUID__c']))
+                except TypeError:
+                    sentry_sdk.capture_message("Adoption {} exists without a book".format(record['Id']))
 
                 # TODO: need to grab current adoptions and if the info has changed, update it so the user sees most recent adoption info
                 # re-submitting the form will update the current year adoption numbers, which the user might not expect

--- a/salesforce/management/commands/update_opportunities.py
+++ b/salesforce/management/commands/update_opportunities.py
@@ -3,7 +3,7 @@ import uuid
 from django.core.management.base import BaseCommand
 from salesforce.models import AdoptionOpportunityRecord
 from salesforce.salesforce import Salesforce
-
+import sentry_sdk
 
 class Command(BaseCommand):
     help = "update book adoptions from salesforce.com for getting adoptions by account uuid"
@@ -41,26 +41,29 @@ class Command(BaseCommand):
                      "AND Opportunity__r.Contact__r.Adoption_Status__c != 'Current Adopter'").format(base_year)
 
             # This generally returns more than 2,000 records (the SF limit)
-            # See simplate_salesforce documentation for query_all: https://github.com/simple-salesforce/simple-salesforce?tab=readme-ov-file#using-bulk
+            # See simplate_salesforce documentation for bulk queries: https://github.com/simple-salesforce/simple-salesforce?tab=readme-ov-file#using-bulk
             results = sf.bulk.Adoption__c.query(query)
 
             # TODO: this doesn't need to be updating on the opp id, the info never changes
             for i, record in enumerate(results):
-                opportunity, created = AdoptionOpportunityRecord.objects.update_or_create(
-                    account_uuid=uuid.UUID(record['Opportunity__r']['Contact__r']['Accounts_UUID__c']),
-                    book_name=record['Opportunity__r']['Book__r']['Name'],
-                    defaults={'opportunity_id': record['Id'],
-                              'opportunity_stage': record['Opportunity__r']['StageName'],
-                              'adoption_type': record['Adoption_Type__c'],
-                              'base_year': record['Base_Year__c'],
-                              'confirmation_date': record['Confirmation_Date__c'],
-                              'confirmation_type': record['Confirmation_Type__c'],
-                              'how_using': record['How_Using__c'],
-                              'savings': record['Savings__c'],
-                              'students': record['Students__c']
-                              }
-                )
-                opportunity.save()
+                try:
+                    opportunity, created = AdoptionOpportunityRecord.objects.update_or_create(
+                        account_uuid=uuid.UUID(record['Opportunity__r']['Contact__r']['Accounts_UUID__c']),
+                        book_name=record['Opportunity__r']['Book__r']['Name'],
+                        defaults={'opportunity_id': record['Id'],
+                                  'opportunity_stage': record['Opportunity__r']['StageName'],
+                                  'adoption_type': record['Adoption_Type__c'],
+                                  'base_year': record['Base_Year__c'],
+                                  'confirmation_date': record['Confirmation_Date__c'],
+                                  'confirmation_type': record['Confirmation_Type__c'],
+                                  'how_using': record['How_Using__c'],
+                                  'savings': record['Savings__c'],
+                                  'students': record['Students__c']
+                                  }
+                    )
+                    opportunity.save()
+                except ValueError:
+                    sentry_sdk.capture_message("Adoption {} has a badly formatted Account UUID: {}".format(record['Id'], record['Opportunity__r']['Contact__r']['Accounts_UUID__c']))
 
                 # TODO: need to grab current adoptions and if the info has changed, update it so the user sees most recent adoption info
                 # re-submitting the form will update the current year adoption numbers, which the user might not expect

--- a/salesforce/management/commands/update_opportunities.py
+++ b/salesforce/management/commands/update_opportunities.py
@@ -5,67 +5,73 @@ from salesforce.models import AdoptionOpportunityRecord
 from salesforce.salesforce import Salesforce
 import sentry_sdk
 
+
 class Command(BaseCommand):
     help = "update book adoptions from salesforce.com for getting adoptions by account uuid"
+
+    def query_base_year(self, base_year, adoption_status):
+        query = ("SELECT Id, "
+                 "Adoption_Type__c, "
+                 "Base_Year__c, "
+                 "Confirmation_Date__c, "
+                 "Confirmation_Type__c, "
+                 "How_Using__c, "
+                 "Savings__c, "
+                 "Students__c, "
+                 "Opportunity__r.Book__r.Name, "
+                 "Opportunity__r.StageName, "
+                 "Opportunity__r.Contact__r.Accounts_UUID__c "
+                 "FROM Adoption__c WHERE "
+                 "Base_Year__c = {} AND Opportunity__r.Contact__r.Accounts_UUID__c  != null "
+                 "AND Confirmation_Type__c = 'OpenStax Confirmed Adoption' "
+                 "AND Opportunity__r.Contact__r.Adoption_Status__c = '{}'").format(base_year, adoption_status)
+
+        return query
+
+    def process_results(self, results):
+        for i, record in enumerate(results):
+            try:
+                opportunity, created = AdoptionOpportunityRecord.objects.update_or_create(
+                    account_uuid=uuid.UUID(record['Opportunity__r']['Contact__r']['Accounts_UUID__c']),
+                    book_name=record['Opportunity__r']['Book__r']['Name'],
+                    defaults={'opportunity_id': record['Id'],
+                              'opportunity_stage': record['Opportunity__r']['StageName'],
+                              'adoption_type': record['Adoption_Type__c'],
+                              'base_year': record['Base_Year__c'],
+                              'confirmation_date': record['Confirmation_Date__c'],
+                              'confirmation_type': record['Confirmation_Type__c'],
+                              'how_using': record['How_Using__c'],
+                              'savings': record['Savings__c'],
+                              'students': record['Students__c']
+                              }
+                )
+                opportunity.save()
+            except ValueError:
+                sentry_sdk.capture_message("Adoption {} has a badly formatted Account UUID: {}".format(record['Id'], record['Opportunity__r']['Contact__r']['Accounts_UUID__c']))
+            except TypeError:
+                sentry_sdk.capture_message("Adoption {} exists without a book".format(record['Id']))
 
     def handle(self, *args, **options):
         with Salesforce() as sf:
             now = datetime.datetime.now()
 
             base_year = now.year
-            if now.month < 7:  # if it's before July, the base year is the previous year (4/1/2024 = base_year 2023)
+            if now.month < 7:  # before july, current year minus 2 (4/1/2024, base year = 2023)
                 base_year -= 2
-            else:
+            else:  # otherwise, current year minus 1 (10/1/2024, base year = 2023)
                 base_year -= 1
 
-            # TODO: I don't think this is needed - updating the records should be fine, and keeps something on the form
-            # TODO: for the user. Eventually, this should update CMS DB with updated data if they fill out the form
-            # truncate the table
-            # AdoptionOpportunityRecord.objects.all().delete()
-
-            # then we will get any new records
-            query = ("SELECT Id, "
-                     "Adoption_Type__c, "
-                     "Base_Year__c, "
-                     "Confirmation_Date__c, "
-                     "Confirmation_Type__c, "
-                     "How_Using__c, "
-                     "Savings__c, "
-                     "Students__c, "
-                     "Opportunity__r.Book__r.Name, "
-                     "Opportunity__r.StageName, "
-                     "Opportunity__r.Contact__r.Accounts_UUID__c "
-                     "FROM Adoption__c WHERE "
-                     "Base_Year__c = {} AND Opportunity__r.Contact__r.Accounts_UUID__c  != null "
-                     "AND Confirmation_Type__c = 'OpenStax Confirmed Adoption' "
-                     "AND Opportunity__r.Contact__r.Adoption_Status__c != 'Current Adopter'").format(base_year)
-
-            # This generally returns more than 2,000 records (the SF limit)
-            # See simplate_salesforce documentation for bulk queries: https://github.com/simple-salesforce/simple-salesforce?tab=readme-ov-file#using-bulk
+            # first, we get last year's records
+            # these people need to renew, show them what we know from last base year confirmed adoption
+            query = self.query_base_year(base_year, "Past Adopter")
             results = sf.bulk.Adoption__c.query(query)
 
-            # TODO: this doesn't need to be updating on the opp id, the info never changes
-            for i, record in enumerate(results):
-                try:
-                    opportunity, created = AdoptionOpportunityRecord.objects.update_or_create(
-                        account_uuid=uuid.UUID(record['Opportunity__r']['Contact__r']['Accounts_UUID__c']),
-                        book_name=record['Opportunity__r']['Book__r']['Name'],
-                        defaults={'opportunity_id': record['Id'],
-                                  'opportunity_stage': record['Opportunity__r']['StageName'],
-                                  'adoption_type': record['Adoption_Type__c'],
-                                  'base_year': record['Base_Year__c'],
-                                  'confirmation_date': record['Confirmation_Date__c'],
-                                  'confirmation_type': record['Confirmation_Type__c'],
-                                  'how_using': record['How_Using__c'],
-                                  'savings': record['Savings__c'],
-                                  'students': record['Students__c']
-                                  }
-                    )
-                    opportunity.save()
-                except ValueError:
-                    sentry_sdk.capture_message("Adoption {} has a badly formatted Account UUID: {}".format(record['Id'], record['Opportunity__r']['Contact__r']['Accounts_UUID__c']))
-                except TypeError:
-                    sentry_sdk.capture_message("Adoption {} exists without a book".format(record['Id']))
+            self.process_results(results)
 
-                # TODO: need to grab current adoptions and if the info has changed, update it so the user sees most recent adoption info
-                # re-submitting the form will update the current year adoption numbers, which the user might not expect
+            # now get this year's records - this will ensure accurate data on the renewal form if already filled out
+            current_base_year = base_year + 1
+            updated_records = self.query_base_year(current_base_year, "Current Adopter")
+
+            results = sf.bulk.Adoption__c.query(updated_records)
+            self.process_results(results)
+

--- a/salesforce/management/commands/update_opportunities.py
+++ b/salesforce/management/commands/update_opportunities.py
@@ -39,7 +39,9 @@ class Command(BaseCommand):
                      "AND Confirmation_Type__c = 'OpenStax Confirmed Adoption' "
                      "AND Opportunity__r.Contact__r.Adoption_Status__c != 'Current Adopter'").format(base_year)
 
-            response = sf.query(query)
+            # This generally returns more than 2,000 records (the SF limit)
+            # See simplate_salesforce documentation for query_all: https://github.com/simple-salesforce/simple-salesforce?tab=readme-ov-file#queries
+            response = sf.query_all(query)
             records = response['records']
 
             for record in records:


### PR DESCRIPTION
This seems to be the way to handle the [2k record limit](https://help.salesforce.com/s/articleView?id=000386264&type=1).

[Simple Salesforce documentation](https://github.com/simple-salesforce/simple-salesforce?tab=readme-ov-file#queries)