### PR TITLE
handle non-useful thank you notes

### DIFF
--- a/salesforce/management/commands/sync_thank_you_notes.py
+++ b/salesforce/management/commands/sync_thank_you_notes.py
@@ -22,9 +22,11 @@ class Command(BaseCommand):
                 # junk removal
                 if note.thank_you_note and len(note.thank_you_note) < 5:  # we expect at least a 'thank'
                     note.delete()
+                # junk school rename
                 if note.institution and note.institution.isdigit():  # we expect at least text
-                    note.institution = None  # Use Find Me A Home
+                    note.institution = "Find Me A Home"  # Use Find Me A Home
                     note.save()
+
 
                 account_id = school_list["Find Me A Home"]
 

--- a/salesforce/management/commands/sync_thank_you_notes.py
+++ b/salesforce/management/commands/sync_thank_you_notes.py
@@ -19,6 +19,13 @@ class Command(BaseCommand):
         with Salesforce() as sf:
             num_created = 0
             for note in new_thank_you_notes:
+                # junk removal
+                if note.thank_you_note and len(note.thank_you_note) < 5:  # we expect at least a 'thank'
+                    note.delete()
+                if note.institution and note.institution.isdigit():  # we expect at least text
+                    note.institution = None  # Use Find Me A Home
+                    note.save()
+
                 account_id = school_list["Find Me A Home"]
 
                 # If note has a school name, see if we can match it and use that account id when creating


### PR DESCRIPTION
We (Data Intel) decided that thank you notes are not very useful if they don't tie back to a school or have a meaningful message. This is to cull those out or assign them to a general school.

**Q: should we keep them in the CMS if they don't meet quality standards?**