### PR TITLE
Impact story 500 fix

### DIFF
--- a/pages/models.py
+++ b/pages/models.py
@@ -1933,15 +1933,6 @@ class ImpactStory(Page):
 
 
 class Impact(Page):
-    improving_access = StreamField(
-        blocks.StreamBlock([
-            ('content', blocks.StructBlock([
-                ('image', ImageBlock()),
-                ('heading', blocks.CharBlock()),
-                ('description', blocks.RichTextBlock()),
-                ('button_text', blocks.CharBlock()),
-                ('button_href', blocks.URLBlock())
-            ]))], max_num=1), use_json_field=True)
     reach = StreamField(
         blocks.StreamBlock([
             ('content', blocks.StructBlock([
@@ -1954,6 +1945,15 @@ class Impact(Page):
                     ('link_text', blocks.CharBlock(required=False)),
                     ('link_href', blocks.URLBlock(required=False))
                 ])))
+            ]))], max_num=1), use_json_field=True)
+    improving_access = StreamField(
+        blocks.StreamBlock([
+            ('content', blocks.StructBlock([
+                ('image', ImageBlock()),
+                ('heading', blocks.CharBlock()),
+                ('description', blocks.RichTextBlock()),
+                ('button_text', blocks.CharBlock()),
+                ('button_href', blocks.URLBlock())
             ]))], max_num=1), use_json_field=True)
     quote = StreamField(
         blocks.StreamBlock([
@@ -2012,8 +2012,8 @@ class Impact(Page):
 
     api_fields = [
         APIField('title'),
-        APIField('improving_access'),
         APIField('reach'),
+        APIField('improving_access'),
         APIField('quote'),
         APIField('making_a_difference'),
         APIField('disruption'),

--- a/pages/models.py
+++ b/pages/models.py
@@ -1923,6 +1923,7 @@ class ImpactStory(Page):
     ]
 
     parent_page_types = ['pages.Impact']
+    template = 'page.html'
 
     def get_url_parts(self, *args, **kwargs):
         return None


### PR DESCRIPTION
- fix the [500 error reported](https://openstax.slack.com/archives/C6NRD0CCQ/p1738938514174069) when viewing impact stories
- move blocks around on the impact page (might also need FE work), requested by Veronica