### PR TITLE
Add FieldPanel for audiobook_link to admin UI

### DIFF
--- a/books/models.py
+++ b/books/models.py
@@ -902,6 +902,7 @@ class Book(Page):
         FieldPanel('bookshare_link'),
         FieldPanel('amazon_coming_soon'),
         FieldPanel('amazon_link'),
+        FieldPanel('audiobook_link'),
         FieldPanel('amazon_iframe'),
         FieldPanel('kindle_link'),
         FieldPanel('chegg_link'),


### PR DESCRIPTION
## Summary

This PR adds the missing `FieldPanel('audiobook_link')` to the Book model's admin configuration. The audiobook_link field was added in PR #1656, but the FieldPanel was omitted, which prevented the field from appearing in the Wagtail CMS admin interface.

## Changes

- Added `FieldPanel('audiobook_link')` to `content_panels` in the Book model
- Positioned after `amazon_link` for logical grouping with other purchase link fields

## Why This Is Needed

Without the FieldPanel, the audiobook_link field exists in the database and API but cannot be edited through the CMS admin UI. This prevented content editors from adding audiobook links to books.

## Testing

- [ ] Verify audiobook_link field appears in the Book edit page in Wagtail admin
- [ ] Verify the field can be edited and saved
- [ ] Verify the field appears in the appropriate section with other purchase links

## Related

- **Jira:** [CORE-1476](https://openstax.atlassian.net/browse/CORE-1476)
- **Related PR:** #1656 (initial audiobook_link field addition)
- **Fixes:** Missing admin UI for audiobook_link field

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CORE-1476]: https://openstax.atlassian.net/browse/CORE-1476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ