### PR TITLE
update_or_create_school to fix existing updates

### DIFF
--- a/salesforce/management/commands/update_schools.py
+++ b/salesforce/management/commands/update_schools.py
@@ -5,6 +5,17 @@ from salesforce.models import School
 from salesforce.salesforce import Salesforce
 
 
+def update_or_create_school(salesforce_id, defaults):
+    school = School.objects.filter(salesforce_id=salesforce_id).order_by('pk').first()
+    if school is None:
+        return School.objects.create(salesforce_id=salesforce_id, **defaults), True
+
+    for field, value in defaults.items():
+        setattr(school, field, value)
+    school.save()
+    return school, False
+
+
 class Command(BaseCommand):
     help = "update schools from salesforce.com"
 
@@ -38,27 +49,28 @@ class Command(BaseCommand):
             for sf_school in sf_schools:
                 salesforce_id = sf_school['Id']
                 seen_salesforce_ids.add(salesforce_id)
-                
-                school, created = School.objects.update_or_create(
+
+                _, created = update_or_create_school(
                     salesforce_id=salesforce_id,
-                    defaults={'name': sf_school['Name'],
-                              'phone': sf_school['Phone'],
-                              'website': sf_school['Website'],
-                              'type': sf_school['Type'],
-                              'industry': sf_school['Industry'],
-                              'location': sf_school['School_Location__c'],
-                              'current_year_students': sf_school['Students_Current_Year__c'],
-                              'total_school_enrollment': sf_school['Total_School_Enrollment__c'],
-                              'physical_country': sf_school['BillingCountry'],
-                              'physical_street': sf_school['BillingStreet'],
-                              'physical_city': sf_school['BillingCity'],
-                              'physical_state_province': sf_school['BillingState'],
-                              'physical_zip_postal_code': sf_school['BillingPostalCode'],
-                              'lat': sf_school['BillingLatitude'],
-                              'long': sf_school['BillingLongitude'],
-                              'research_agreement_start_date': sf_school['Research_Agreement_Start_Date__c'],
-                              'research_agreement_end_date': sf_school['Research_Agreement_End_Date__c'],
-                              },
+                    defaults={
+                        'name': sf_school['Name'],
+                        'phone': sf_school['Phone'],
+                        'website': sf_school['Website'],
+                        'type': sf_school['Type'],
+                        'industry': sf_school['Industry'],
+                        'location': sf_school['School_Location__c'],
+                        'current_year_students': sf_school['Students_Current_Year__c'],
+                        'total_school_enrollment': sf_school['Total_School_Enrollment__c'],
+                        'physical_country': sf_school['BillingCountry'],
+                        'physical_street': sf_school['BillingStreet'],
+                        'physical_city': sf_school['BillingCity'],
+                        'physical_state_province': sf_school['BillingState'],
+                        'physical_zip_postal_code': sf_school['BillingPostalCode'],
+                        'lat': sf_school['BillingLatitude'],
+                        'long': sf_school['BillingLongitude'],
+                        'research_agreement_start_date': sf_school['Research_Agreement_Start_Date__c'],
+                        'research_agreement_end_date': sf_school['Research_Agreement_End_Date__c'],
+                    },
                 )
 
                 if created:

--- a/salesforce/tests.py
+++ b/salesforce/tests.py
@@ -1,6 +1,7 @@
 import datetime
 import vcr
 import json
+from unittest.mock import patch
 
 from django.core.management import call_command
 from django.test import LiveServerTestCase, TestCase, Client
@@ -10,7 +11,7 @@ from django.conf import settings
 
 from books.models import BookIndex, Book
 from pages.models import HomePage
-from salesforce.models import SalesforceSettings, MapBoxDataset, Partner, AdoptionOpportunityRecord, SalesforceForms
+from salesforce.models import SalesforceSettings, MapBoxDataset, Partner, AdoptionOpportunityRecord, SalesforceForms, School
 from salesforce.salesforce import Salesforce as SF
 from salesforce.serializers import PartnerSerializer
 
@@ -130,6 +131,49 @@ class MapboxTest(TestCase):
         setting = self.create_mapbox_setting()
         self.assertTrue(isinstance(setting, MapBoxDataset))
         self.assertEqual(setting.__str__(), setting.name)
+
+
+class UpdateSchoolsCommandTest(TestCase):
+    def sf_school(self, **overrides):
+        school = {
+            'Id': '001duplicate',
+            'Name': 'Salesforce School',
+            'Phone': '555-1212',
+            'Website': 'https://example.edu',
+            'Type': 'College',
+            'Industry': 'HE',
+            'School_Location__c': 'Urban',
+            'Students_Current_Year__c': '123',
+            'Total_School_Enrollment__c': '4567',
+            'BillingCountry': 'United States',
+            'BillingStreet': '123 Main St',
+            'BillingCity': 'Houston',
+            'BillingState': 'TX',
+            'BillingPostalCode': '77030',
+            'BillingLatitude': '29.720',
+            'BillingLongitude': '-95.397',
+            'Research_Agreement_Start_Date__c': datetime.date(2026, 1, 1),
+            'Research_Agreement_End_Date__c': datetime.date(2026, 12, 31),
+        }
+        school.update(overrides)
+        return school
+
+    @patch('salesforce.management.commands.update_schools.invalidate_cloudfront_caches')
+    @patch('salesforce.management.commands.update_schools.Salesforce')
+    def test_update_schools_updates_first_duplicate_salesforce_id(self, salesforce, _invalidate):
+        first_school = School.objects.create(salesforce_id='001duplicate', name='First duplicate')
+        second_school = School.objects.create(salesforce_id='001duplicate', name='Second duplicate')
+
+        sf = salesforce.return_value.__enter__.return_value
+        sf.bulk.Account.query.return_value = [[self.sf_school()]]
+
+        call_command('update_schools')
+
+        first_school.refresh_from_db()
+        second_school.refresh_from_db()
+        self.assertEqual(first_school.name, 'Salesforce School')
+        self.assertEqual(second_school.name, 'Second duplicate')
+        self.assertEqual(School.objects.filter(salesforce_id='001duplicate').count(), 2)
 
 
 class AdoptionOpportunityTest(TestCase):


### PR DESCRIPTION
This pull request refactors how schools are updated or created from Salesforce data to handle duplicate `salesforce_id` values more predictably and adds a test to ensure only the first matching school is updated. It also introduces a helper function to encapsulate this logic and expands test coverage for the update process.

**Refactor for handling duplicate schools:**

* Added a new helper function `update_or_create_school` in `update_schools.py` to update only the first `School` instance found with a given `salesforce_id`, instead of updating all matches. This ensures that only the first duplicate is modified, and others remain unchanged.
* Updated the command logic in `handle` to use the new `update_or_create_school` function, replacing the previous use of `School.objects.update_or_create`.

**Test improvements:**

* Added a new test class `UpdateSchoolsCommandTest` to `salesforce/tests.py` with a test verifying that when multiple `School` objects share a `salesforce_id`, only the first one is updated by the management command.
* Imported the `School` model into `salesforce/tests.py` to support the new test.
* Added `patch` import to allow mocking dependencies in tests.