### PR TITLE
update vars to calculate base year

### DIFF
--- a/salesforce/management/commands/update_opportunities.py
+++ b/salesforce/management/commands/update_opportunities.py
@@ -32,6 +32,11 @@ class Command(BaseCommand):
 
         return query
 
+    def school_year_base_year(self, date):
+        if date.month < 7:
+            return date.year - 1
+        return date.year
+
     def account_uuid(self, record):
         """Return the parsed Accounts UUID for a Salesforce adoption record.
 
@@ -106,19 +111,14 @@ class Command(BaseCommand):
     @monitor(monitor_slug='update-opportunities')
     def handle(self, *args, **options):
         with Salesforce() as sf:
-            now = datetime.datetime.now()
-
-            base_year = now.year
-            if now.month < 7:  # before july, current year minus 2 (4/1/2024, base year = 2023)
-                base_year -= 2
-            else:  # otherwise, current year minus 1 (10/1/2024, base year = 2023)
-                base_year -= 1
+            current_base_year = self.school_year_base_year(datetime.datetime.now().date())
+            previous_base_year = current_base_year - 1
 
             # First, last year's confirmed adoptions for past adopters: these people
             # need to renew, so we surface what we know from last base year so the
             # frontend can show them the renewal nudge.
             past_adopters = sf.bulk.Adoption__c.query(
-                self.query_base_year(base_year, "Past Adopter")
+                self.query_base_year(previous_base_year, "Past Adopter")
             )
             with transaction.atomic():
                 self.process_results(past_adopters)
@@ -127,7 +127,6 @@ class Command(BaseCommand):
             # already confirmed for the current base year, so replace last year's
             # nudge data with the accurate current-year records. We clear every
             # current adopter's existing rows once, in bulk, then upsert.
-            current_base_year = base_year + 1
             current_adopters = sf.bulk.Adoption__c.query(
                 self.query_base_year(current_base_year, "Current Adopter")
             )

--- a/salesforce/tests.py
+++ b/salesforce/tests.py
@@ -12,6 +12,7 @@ from django.conf import settings
 from books.models import BookIndex, Book
 from pages.models import HomePage
 from salesforce.models import SalesforceSettings, MapBoxDataset, Partner, AdoptionOpportunityRecord, SalesforceForms, School
+from salesforce.management.commands.update_opportunities import Command as UpdateOpportunitiesCommand
 from salesforce.salesforce import Salesforce as SF
 from salesforce.serializers import PartnerSerializer
 
@@ -219,6 +220,32 @@ class UpdateOpportunitiesCommandTest(TestCase):
             sf = salesforce.return_value.__enter__.return_value
             sf.bulk.Adoption__c.query.side_effect = [past_results, current_results]
             call_command('update_opportunities')
+
+    def test_school_year_base_year_rolls_over_in_july(self):
+        command = UpdateOpportunitiesCommand()
+
+        self.assertEqual(command.school_year_base_year(datetime.date(2024, 6, 30)), 2023)
+        self.assertEqual(command.school_year_base_year(datetime.date(2024, 7, 1)), 2024)
+        self.assertEqual(command.school_year_base_year(datetime.date(2024, 10, 1)), 2024)
+
+    def test_october_sync_queries_previous_then_current_school_year_base_year(self):
+        real_datetime = datetime.datetime
+
+        with patch('salesforce.management.commands.update_opportunities.datetime.datetime') as dt, \
+                patch('salesforce.management.commands.update_opportunities.invalidate_cloudfront_caches'), \
+                patch('salesforce.management.commands.update_opportunities.Salesforce') as salesforce:
+            dt.now.return_value = real_datetime(2024, 10, 1)
+            sf = salesforce.return_value.__enter__.return_value
+            sf.bulk.Adoption__c.query.side_effect = [[], []]
+
+            call_command('update_opportunities')
+
+        past_query = sf.bulk.Adoption__c.query.call_args_list[0].args[0]
+        current_query = sf.bulk.Adoption__c.query.call_args_list[1].args[0]
+        self.assertIn("Base_Year__c = 2023", past_query)
+        self.assertIn("Adoption_Status__c = 'Past Adopter'", past_query)
+        self.assertIn("Base_Year__c = 2024", current_query)
+        self.assertIn("Adoption_Status__c = 'Current Adopter'", current_query)
 
     def test_existing_opportunity_is_updated_not_duplicated(self):
         # A row already exists for this Salesforce Adoption Id, but with a stale


### PR DESCRIPTION
This pull request refactors how the base year is determined for Salesforce adoption opportunities and adds corresponding tests to ensure the correct school-year logic is applied. The main improvement is centralizing the base year calculation to handle the July rollover consistently, which affects how past and current adopters are queried.

**Base year calculation improvements:**

* Added a new method `school_year_base_year` to encapsulate the logic for determining the base year based on the current date, ensuring that before July the base year is the previous year, and from July onward it is the current year. (`salesforce/management/commands/update_opportunities.py`)
* Updated the `handle` method to use `school_year_base_year` for both current and previous base years, replacing duplicated and error-prone base year logic. (`salesforce/management/commands/update_opportunities.py`) [[1]](diffhunk://#diff-549fb50b44357830f152ed776c811d20b723e5824c4af82a583c2be6caefbde5L109-R121) [[2]](diffhunk://#diff-549fb50b44357830f152ed776c811d20b723e5824c4af82a583c2be6caefbde5L130)

**Testing enhancements:**

* Added tests to verify that `school_year_base_year` rolls over in July as expected, and that the command queries the correct base years and adoption statuses for both past and current adopters depending on the date. (`salesforce/tests.py`) [[1]](diffhunk://#diff-d01722d7444800b0b2e1d8592954b764e84ab24d66c3446ab91f7269e9bab402R224-R249) [[2]](diffhunk://#diff-d01722d7444800b0b2e1d8592954b764e84ab24d66c3446ab91f7269e9bab402R15)

These changes make the base year logic more robust and easier to maintain, and the new tests help prevent regressions.