### PR TITLE
Wagtail transfer import status guard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,173 @@
+# OpenStax CMS - Codex Agent Guide
+
+## Overview
+
+OpenStax CMS is a content management system built with **Wagtail CMS** on top of **Django Framework**. It manages content for openstax.org including books, pages, news, and various marketing pages.
+
+## Technology Stack
+
+- **Framework**: Django 5.2
+- **CMS**: Wagtail 7.4 (LTS)
+- **Database**: PostgreSQL (≥ 13) or SQLite
+- **Language**: Python ≥ 3.11 (project virtualenv runs 3.14)
+
+## Local Environment (IMPORTANT)
+
+This project uses a **virtualenv** — always work inside it. Do **not** use the
+system/Homebrew Python (it is externally managed; `pip install` is blocked there).
+
+```bash
+workon openstax-cms          # virtualenvwrapper; venv lives at ~/.virtualenvs/openstax-cms
+```
+
+Run every `python manage.py …`, `pip install`, and test command inside that venv.
+If `workon` isn't available, activate directly:
+`source ~/.virtualenvs/openstax-cms/bin/activate`.
+
+### Running tests
+
+```bash
+python manage.py test --settings=openstax.settings.test            # full suite
+python manage.py test authoring --settings=openstax.settings.test
+```
+
+Add `--noinput` if a leftover `test_oscms_test` DB blocks a run, or `--keepdb` to
+reuse the test DB between runs. CI installs `requirements/test.txt` and runs
+`manage.py test --settings=openstax.settings.test`.
+
+## Project Structure
+
+```
+openstax-cms/
+├── pages/              # Core page models (Assignable, Book pages, etc.)
+│   ├── models/         # Wagtail page types, split into themed modules
+│   │   ├── __init__.py # Re-exports everything: import from pages.models, not submodules
+│   │   ├── constants.py # Shared StreamField block-list constants
+│   │   ├── bases.py    # Concrete MTI base models (Quote, Institutions, Group)
+│   │   ├── core.py     # RootPage, FlexPage, HomePage, GeneralPage
+│   │   └── …           # about, giving, legal, support, partners, marketing, subjects, k12
+│   ├── migrations/     # Django migrations
+│   └── custom_blocks.py # StreamField blocks
+├── books/              # Book-specific models and logic
+├── news/               # News/blog functionality
+├── errata/             # Errata submission and management
+├── accounts/           # Account-related functionality
+├── api/                # API endpoints
+├── openstax/           # Project settings
+│   └── settings/       # Environment-specific settings
+│       ├── base.py     # Base settings
+│       ├── local.py.example # Local dev settings template
+│       ├── test.py     # Test settings
+│       └── docker.py   # Docker settings
+├── requirements/       # Python dependencies
+│   ├── base.txt        # Core requirements
+│   ├── dev.txt         # Development requirements
+│   ├── test.txt        # Test requirements
+│   └── production.txt  # Production requirements
+└── manage.py           # Django management script
+```
+
+## Setup Instructions
+
+### Prerequisites
+
+- Python ≥ 3.11
+- PostgreSQL ≥ 13 (or use SQLite for development)
+- pip (Python package manager)
+
+### Installation Steps
+
+1. **Clone the repository**
+2. **Activate the virtualenv** (`workon openstax-cms`)
+3. **Install Python dependencies from requirements/dev.txt**
+4. **Create local settings file** (REQUIRED before migrations): `cp openstax/settings/local.py.example openstax/settings/local.py`
+
+## Creating Django Migrations
+
+When you modify model fields in `pages/models/` or other model files:
+
+1. **Ensure openstax/settings/local.py exists**
+2. **Install dev requirements**
+3. **Generate migration**:
+   ```bash
+   python3 manage.py makemigrations
+   ```
+
+   This creates a new migration file in the appropriate `migrations/` directory.
+
+4. **Review the migration**
+5. **Commit both model changes and migration**
+
+### Migration Best Practices
+
+- **Always create local.py first** - Without it, Django may use incorrect drivers
+- **Use makemigrations** - Don't write migrations manually
+- **One logical change per migration** - Keep migrations focused
+- **Include in PR** - Always commit migrations with model changes
+
+## Wagtail Concepts
+
+- **Page models**: Inherit from `wagtail.models.Page`
+- **content_panels**: Define fields shown in Wagtail admin
+- **api_fields**: Define fields exposed via API
+- **StreamFields**: Flexible content blocks (see `custom_blocks.py`)
+
+## API
+
+API endpoints documented at: https://github.com/openstax/openstax-cms/wiki/API-Endpoints
+
+Postman collection: https://www.postman.com/openstax/workspace/cms/overview
+
+## Headless Authoring & Draft-Save API
+
+This branch adds an authenticated path for an AI agent (and, soon, an in-CMS MCP
+server) to create/update `FlexPage`s as **unpublished drafts** — it **never
+publishes** (a human reviews and publishes in the Wagtail admin).
+
+- **Endpoint:** `POST /apps/cms/api/v2/pages/flex/` (create) and
+  `PATCH /apps/cms/api/v2/pages/flex/<id>/` (update). Token-auth fast-path
+  (`rest_framework.authtoken`); the global API stays public-read (`AllowAny`) — the
+  write view sets its own auth/permission classes.
+- **App:** everything lives in the `authoring/` app (kept out of `pages`, which
+  is already the most complex app). The page models themselves stay in `pages`.
+- **Service layer (surface-agnostic; the MCP tools will reuse it):**
+  - `authoring/drafts.py` — validate `layout`/`body` against the real block defs,
+    `create_flex_draft` / `update_flex_draft` (draft revisions only), rich-text
+    reference validation, page-lock check.
+  - `authoring/routing_rules.py` — reserved slugs, `RootPage`-only parents, **tree-global**
+    slug uniqueness (FlexPage URLs flatten to `/<slug>`).
+  - `authoring/permissions.py` — `CanDraftFlexPages` (staff + Wagtail page perms).
+  - `authoring/views.py` — the DRF view; routes in `authoring/urls.py`, included
+    from `openstax/urls.py` under `/apps/cms/api/v2/pages/flex/`.
+  - Tests: `authoring/tests/`.
+- **Contract for clients:** `docs/api/flex-draft-save.md`.
+- **Design & plans (not committed; local `docs/superpowers/`):** the headless +
+  AI-authoring spec and the in-CMS MCP server plan (`django-mcp-server` +
+  `django-oauth-toolkit` + DCR) live there.
+
+Wagtail 7.4 note: prefer **deferred validation** for draft saves (required-field
+checks happen at publish time) and `ImageRenditionField` for headless images.
+
+## Additional Documentation
+
+- [CMS Editing Documentation](https://openstax.atlassian.net/wiki/spaces/BIT/pages/2193391617/CMS+Editing)
+- [CMS Branching and Releases](https://openstax.atlassian.net/wiki/spaces/BIT/pages/2207219713/CMS+Branching+and+Releases)
+- [CMS Pull Requests](https://openstax.atlassian.net/wiki/spaces/BIT/pages/2207252512/CMS+Pull+Requests)
+
+## Troubleshooting
+
+### Import errors with botocore.vendored
+
+If you see: `ModuleNotFoundError: No module named 'botocore.vendored'`
+
+**Cause**: The `django_ses` package in `INSTALLED_APPS` requires botocore, which changed in newer versions.
+
+**Solution**: This is expected in local development. The error occurs because production uses SES for email, but local development doesn't need it. Your `local.py` file should already handle this, but if needed:
+
+```python
+# In openstax/settings/local.py
+from .base import INSTALLED_APPS
+
+# Remove django_ses from INSTALLED_APPS
+INSTALLED_APPS = tuple(app for app in INSTALLED_APPS if app != 'django_ses')
+```

--- a/global_settings/static/global_settings/css/wagtail_transfer_chooser.css
+++ b/global_settings/static/global_settings/css/wagtail_transfer_chooser.css
@@ -1,0 +1,21 @@
+/*
+ * wagtail-transfer 0.11 chooser pagination fix for Wagtail 7.4.
+ *
+ * The chooser ("Choose a page or snippet" import screen) renders its
+ * Previous/Next pagination arrows as
+ *     <svg class="icon icon-arrow-left navigate-pages">
+ *     <svg class="icon icon-arrow-right navigate-pages">
+ * relying on a global `.icon { width; height }` rule that older Wagtail
+ * shipped. Wagtail 7.4's core.css only sizes `.icon` *inside* specific
+ * component containers (e.g. `.c-page-explorer__item__link .icon`); there is
+ * no unscoped `.icon` size rule anymore, so these chevrons fall back to their
+ * intrinsic SVG size and render enormous.
+ *
+ * `.navigate-pages` is used only by the wagtail-transfer chooser, so this is
+ * safe to load globally via insert_global_admin_css.
+ */
+svg.icon.navigate-pages {
+    width: 1.5rem;
+    height: 1.5rem;
+    vertical-align: middle;
+}

--- a/global_settings/tests.py
+++ b/global_settings/tests.py
@@ -76,3 +76,19 @@ class ExperimentsGuideTest(WagtailTestUtils, TestCase):
         response = self.client.get(reverse('experiments_guide'))
         # require_admin_access redirects anonymous users to the admin login.
         self.assertIn(response.status_code, (302, 403))
+
+
+class WagtailTransferChooserCssHookTest(TestCase):
+    """The wagtail-transfer chooser renders its pagination arrows as
+    <svg class="icon ... navigate-pages">, relying on a global `.icon` size
+    that Wagtail 7.4 dropped. We inject a scoped stylesheet via the
+    insert_global_admin_css hook (loaded on every admin page, including the
+    chooser) to size them back down."""
+
+    def test_global_admin_css_links_the_transfer_chooser_stylesheet(self):
+        from wagtail import hooks
+
+        outputs = ''.join(str(fn()) for fn in hooks.get_hooks('insert_global_admin_css'))
+
+        self.assertIn('<link', outputs)
+        self.assertIn('wagtail_transfer_chooser', outputs)

--- a/global_settings/wagtail_hooks.py
+++ b/global_settings/wagtail_hooks.py
@@ -1,10 +1,22 @@
 import wagtail.admin.rich_text.editors.draftail.features as draftail_features
 from wagtail.admin.rich_text.converters.html_to_contentstate import InlineStyleElementHandler
 from wagtail import hooks
+from django.templatetags.static import static
 from django.urls import path, reverse
+from django.utils.html import format_html
 from wagtail.admin.menu import Menu, MenuItem, SubmenuMenuItem
 
 from global_settings import views
+
+
+@hooks.register('insert_global_admin_css')
+def wagtail_transfer_chooser_css():
+    """Size the wagtail-transfer chooser's pagination arrows, which 7.4 no
+    longer styles (see the stylesheet's comment for the full why)."""
+    return format_html(
+        '<link rel="stylesheet" href="{}">',
+        static('global_settings/css/wagtail_transfer_chooser.css'),
+    )
 
 
 # A nested "Tools" menu for developer/operations utilities (Import, Versions, …)

--- a/openstax/settings/base.py
+++ b/openstax/settings/base.py
@@ -282,6 +282,19 @@ INSTALLED_APPS = [
 WAGTAILTRANSFER_SECRET_KEY = os.getenv('WAGTAILTRANSFER_SECRET_KEY', 'change-me-in-production')
 WAGTAILTRANSFER_INSECURE_SECRET_KEY = 'change-me-in-production'
 
+# Models the importer must NOT follow into when it encounters a reference.
+# This is the package default (wagtailcore.page, contenttypes.contenttype) plus
+# auth.user: transferred objects such as wagtailcore.revision carry a `user` FK,
+# and following it would 404 on the export allowlist (auth.user is intentionally
+# not exportable) and try to pull user PII across. Leaving it unfollowed nulls
+# the FK instead — fine, since these user FKs are nullable. Keep the two package
+# defaults here; this setting REPLACES the default rather than extending it.
+WAGTAILTRANSFER_NO_FOLLOW_MODELS = [
+    'wagtailcore.page',
+    'contenttypes.contenttype',
+    'auth.user',
+]
+
 # The secret key is validated two ways, both living outside this (declarative)
 # settings module:
 #   1. global_settings.checks._check_wagtail_transfer_secret_key — a Django

--- a/openstax/wagtail_transfer_patches.py
+++ b/openstax/wagtail_transfer_patches.py
@@ -1,29 +1,50 @@
 """
 Runtime patches for wagtail-transfer 0.11.
 
-When importing pages, an Objective is occasionally constructed with a Page
-subclass (e.g. pages.RootPage) instead of the base wagtailcore.Page. The
-import context's uids_by_source / destination_ids_by_source dicts are keyed
-by base model, so the subclass lookup raises KeyError in
-Objective._find_at_destination (operations.py: `uids_by_source[(self.model,
-self.source_id)]`). Objective.__eq__/__hash__ also key on self.model, so
-normalizing in __init__ additionally fixes set-dedup of objectives.
+Two patches, both installed by `apply_patches()`:
 
-Every other call site in wagtail-transfer normalizes via get_base_model() —
-this patch closes the one gap that leaks the subclass through. Upstream issue:
-https://github.com/wagtail/wagtail-transfer/issues/127 (open as of 0.11).
+1. Objective base-model normalization. When importing pages, an Objective is
+   occasionally constructed with a Page subclass (e.g. pages.RootPage) instead
+   of the base wagtailcore.Page. The import context's uids_by_source /
+   destination_ids_by_source dicts are keyed by base model, so the subclass
+   lookup raises KeyError in Objective._find_at_destination (operations.py:
+   `uids_by_source[(self.model, self.source_id)]`). Objective.__eq__/__hash__
+   also key on self.model, so normalizing in __init__ additionally fixes
+   set-dedup of objectives. Every other call site in wagtail-transfer normalizes
+   via get_base_model() — this patch closes the one gap that leaks the subclass
+   through. Upstream issue:
+   https://github.com/wagtail/wagtail-transfer/issues/127 (open as of 0.11).
+
+2. add_json error clarity. The import views (import_page / import_model /
+   import_missing_object_data) pass the source's raw HTTP response body straight
+   to ImportPlanner.add_json() without checking the status code. When the source
+   returns anything but the expected JSON — a 403 (WAGTAILTRANSFER_SECRET_KEY
+   mismatch), a 404 (page/object missing on the source, or a model rejected by
+   our export allowlist), or — because this CMS is headless — the frontend SPA
+   shell for a 404, add_json's json.loads() blows up with the opaque
+   "Expecting value: line 1 column 1 (char 0)". This patch wraps add_json to
+   re-raise that as a WagtailTransferImportError quoting the source's actual
+   response, so the real cause is visible. It guards add_json (the shared
+   chokepoint of all three import flows) rather than the view bodies, so the
+   chooser proxy's deliberate status passthrough is untouched and we copy no
+   upstream view logic that could drift when the pin moves.
 
 `apply_patches()` is idempotent and is called from
 global_settings.apps.GlobalSettingsConfig.ready(), so it runs in every process
 that calls django.setup() — management commands, shell, Celery, WSGI/ASGI —
 not only when the URLconf happens to be imported.
 """
+import json
 import logging
 
 from wagtail_transfer.models import get_base_model
-from wagtail_transfer.operations import Objective
+from wagtail_transfer.operations import ImportPlanner, Objective
 
 logger = logging.getLogger(__name__)
+
+
+class WagtailTransferImportError(Exception):
+    """A wagtail-transfer source returned a non-JSON (HTTP error) response."""
 
 # The patched signature mirrors Objective.__init__ in this exact release. If the
 # pin in requirements/base.txt moves, re-verify the signature and whether the
@@ -31,11 +52,37 @@ logger = logging.getLogger(__name__)
 EXPECTED_WAGTAIL_TRANSFER_VERSION = '0.11'
 
 _PATCH_FLAG = '_openstax_base_model_patch'
+_ADD_JSON_PATCH_FLAG = '_openstax_add_json_guard'
 
 
 def _patched_init(self, model, source_id, context, must_update=False):
     _original_init = _patched_init._original
     _original_init(self, get_base_model(model), source_id, context, must_update)
+
+
+def _response_snippet(json_data, limit=300):
+    """First `limit` chars of the source response, for the error message."""
+    if isinstance(json_data, (bytes, bytearray)):
+        text = json_data.decode('utf-8', errors='replace')
+    else:
+        text = str(json_data)
+    return text.strip()[:limit]
+
+
+def _patched_add_json(self, json_data):
+    try:
+        return _patched_add_json._original(self, json_data)
+    except json.JSONDecodeError as exc:
+        raise WagtailTransferImportError(
+            "wagtail-transfer received a non-JSON response from the source site, "
+            "so the import could not be read. The source almost certainly returned "
+            "an HTTP error page instead of export data: a 403 (the source's "
+            "WAGTAILTRANSFER_SECRET_KEY does not match the SECRET_KEY this "
+            "environment has configured for it), a 404 (the page/object does not "
+            "exist on the source, BASE_URL is wrong, or the model is not in the "
+            "export allowlist), or this site's headless frontend shell. "
+            f"Source response began with:\n{_response_snippet(json_data)}"
+        ) from exc
 
 
 def apply_patches():
@@ -52,9 +99,12 @@ def apply_patches():
             installed, EXPECTED_WAGTAIL_TRANSFER_VERSION,
         )
 
-    if getattr(Objective.__init__, _PATCH_FLAG, False):
-        return  # already patched
+    if not getattr(Objective.__init__, _PATCH_FLAG, False):
+        _patched_init._original = Objective.__init__
+        setattr(_patched_init, _PATCH_FLAG, True)
+        Objective.__init__ = _patched_init
 
-    _patched_init._original = Objective.__init__
-    setattr(_patched_init, _PATCH_FLAG, True)
-    Objective.__init__ = _patched_init
+    if not getattr(ImportPlanner.add_json, _ADD_JSON_PATCH_FLAG, False):
+        _patched_add_json._original = ImportPlanner.add_json
+        setattr(_patched_add_json, _ADD_JSON_PATCH_FLAG, True)
+        ImportPlanner.add_json = _patched_add_json

--- a/openstax/wagtail_transfer_patches.py
+++ b/openstax/wagtail_transfer_patches.py
@@ -87,6 +87,7 @@ def _patched_add_json(self, json_data):
 
 def apply_patches():
     """Install the wagtail-transfer runtime patches. Idempotent."""
+    try:
         import importlib.metadata as _md
         installed = _md.version('wagtail-transfer')
     except Exception:  # pragma: no cover - metadata always present in practice

--- a/openstax/wagtail_transfer_patches.py
+++ b/openstax/wagtail_transfer_patches.py
@@ -72,7 +72,7 @@ def _response_snippet(json_data, limit=300):
 def _patched_add_json(self, json_data):
     try:
         return _patched_add_json._original(self, json_data)
-    except json.JSONDecodeError as exc:
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
         raise WagtailTransferImportError(
             "wagtail-transfer received a non-JSON response from the source site, "
             "so the import could not be read. The source almost certainly returned "
@@ -86,8 +86,7 @@ def _patched_add_json(self, json_data):
 
 
 def apply_patches():
-    """Install the Objective base-model normalization patch. Idempotent."""
-    try:
+    """Install the wagtail-transfer runtime patches. Idempotent."""
         import importlib.metadata as _md
         installed = _md.version('wagtail-transfer')
     except Exception:  # pragma: no cover - metadata always present in practice

--- a/openstax/wagtail_transfer_security.py
+++ b/openstax/wagtail_transfer_security.py
@@ -28,8 +28,15 @@ from django.http import Http404
 
 # Models always allowed through the object/model export endpoints, on top of
 # whatever snippets are configured for transfer via WAGTAILTRANSFER_LOOKUP_FIELDS.
+#
+# wagtailcore.revision is required: importing a page fetches its latest revision
+# (the content snapshot) via api/objects/, so without it the import 404s. The
+# revision's `user` FK is not a leak risk here because auth.user is in
+# WAGTAILTRANSFER_NO_FOLLOW_MODELS (settings/base.py) — the importer leaves it
+# null rather than pulling the user across.
 _ALWAYS_EXPORTABLE = {
     'wagtailcore.page',
+    'wagtailcore.revision',
     'wagtailimages.image',
     'wagtaildocs.document',
     'wagtailcore.locale',

--- a/pages/tests/test_wagtail_transfer_patches.py
+++ b/pages/tests/test_wagtail_transfer_patches.py
@@ -47,27 +47,33 @@ class AddJsonGuardTests(TestCase):
         return ImportPlanner.for_page(source=1, destination=None, source_site='test')
 
     def test_non_json_response_does_not_raise_opaque_jsondecodeerror(self):
+        from openstax.wagtail_transfer_patches import WagtailTransferImportError
+
         apply_patches()
 
-        with self.assertRaises(Exception) as ctx:
+        with self.assertRaises(WagtailTransferImportError) as ctx:
             self._importer().add_json(HTML_403)
 
         # The whole point: the caller must not see a bare JSONDecodeError.
         self.assertNotIsInstance(ctx.exception, json.JSONDecodeError)
 
     def test_error_message_includes_the_source_response_body(self):
+        from openstax.wagtail_transfer_patches import WagtailTransferImportError
+
         apply_patches()
 
-        with self.assertRaises(Exception) as ctx:
+        with self.assertRaises(WagtailTransferImportError) as ctx:
             self._importer().add_json(HTML_403)
 
         # The source's actual response is the diagnostic — surface it.
         self.assertIn('403 Forbidden', str(ctx.exception))
 
     def test_spa_shell_response_is_identified_in_the_message(self):
+        from openstax.wagtail_transfer_patches import WagtailTransferImportError
+
         apply_patches()
 
-        with self.assertRaises(Exception) as ctx:
+        with self.assertRaises(WagtailTransferImportError) as ctx:
             self._importer().add_json(SPA_SHELL_404)
 
         self.assertIn('OpenStax', str(ctx.exception))

--- a/pages/tests/test_wagtail_transfer_patches.py
+++ b/pages/tests/test_wagtail_transfer_patches.py
@@ -1,8 +1,10 @@
 """Tests for the wagtail-transfer Objective base-model monkeypatch."""
+import json
+
 from django.test import TestCase
 
 from wagtail_transfer.models import get_base_model
-from wagtail_transfer.operations import Objective
+from wagtail_transfer.operations import ImportPlanner, Objective
 
 from openstax.wagtail_transfer_patches import apply_patches
 
@@ -19,3 +21,61 @@ class ObjectivePatchTests(TestCase):
         # Without the patch, objective.model would be RootPage and the
         # uids_by_source lookup (keyed by base model) would KeyError.
         self.assertIs(objective.model, get_base_model(RootPage))
+
+
+# A Django/nginx HTTP error page — what the wagtail-transfer source returns on a
+# failed digest check, a missing page, or an allowlist rejection. The importer's
+# add_json() json-parses the response body blindly, so without a guard this
+# surfaces as an opaque JSONDecodeError instead of the real cause.
+HTML_403 = (
+    b'\n<!doctype html>\n<html lang="en">\n<head>\n  <title>403 Forbidden</title>\n'
+    b'</head>\n<body>\n  <h1>403 Forbidden</h1><p></p>\n</body>\n</html>\n'
+)
+# The headless openstax.org frontend shell — what a 404 from the CMS resolves to
+# when the export request lands on the SPA fallback rather than Django.
+SPA_SHELL_404 = (
+    b'<!doctype html><html lang="en-US"><head><title>OpenStax</title>'
+    b'<meta name="description" content="OpenStax offers free college textbooks">'
+    b'</head><body></body></html>'
+)
+
+
+class AddJsonGuardTests(TestCase):
+    def _importer(self):
+        # for_page() only stores attributes; add_json fails (or succeeds) on the
+        # payload before any DB access, so no fixtures are needed.
+        return ImportPlanner.for_page(source=1, destination=None, source_site='test')
+
+    def test_non_json_response_does_not_raise_opaque_jsondecodeerror(self):
+        apply_patches()
+
+        with self.assertRaises(Exception) as ctx:
+            self._importer().add_json(HTML_403)
+
+        # The whole point: the caller must not see a bare JSONDecodeError.
+        self.assertNotIsInstance(ctx.exception, json.JSONDecodeError)
+
+    def test_error_message_includes_the_source_response_body(self):
+        apply_patches()
+
+        with self.assertRaises(Exception) as ctx:
+            self._importer().add_json(HTML_403)
+
+        # The source's actual response is the diagnostic — surface it.
+        self.assertIn('403 Forbidden', str(ctx.exception))
+
+    def test_spa_shell_response_is_identified_in_the_message(self):
+        apply_patches()
+
+        with self.assertRaises(Exception) as ctx:
+            self._importer().add_json(SPA_SHELL_404)
+
+        self.assertIn('OpenStax', str(ctx.exception))
+
+    def test_valid_payload_still_parses(self):
+        apply_patches()
+
+        # An empty-but-valid payload exercises the wrapped add_json without
+        # touching the DB; it must pass straight through the guard.
+        payload = json.dumps({'ids_for_import': [], 'mappings': [], 'objects': []})
+        self._importer().add_json(payload)  # must not raise

--- a/pages/tests/test_wagtail_transfer_security.py
+++ b/pages/tests/test_wagtail_transfer_security.py
@@ -49,3 +49,32 @@ class ExportApiSecurityTests(TestCase):
             url = self._models_url('snippets.subject')
             resp = self.client.get(url, {'digest': 'not-a-valid-digest'})
         self.assertEqual(resp.status_code, 403)
+
+
+class ExportableModelAllowlistTests(TestCase):
+    def test_revision_is_exportable(self):
+        # Importing a page fetches its latest revision via api/objects/; without
+        # wagtailcore.revision on the allowlist the whole import 404s on it.
+        from openstax.wagtail_transfer_security import get_exportable_model_labels
+
+        self.assertIn('wagtailcore.revision', get_exportable_model_labels())
+
+
+class NoFollowModelsTests(TestCase):
+    """Revisions (and other transferred objects) carry a `user` FK. Following it
+    would 404 on the export allowlist and attempt to pull user PII across, so
+    auth.user must stay unfollowed (left as a null FK). The two package defaults
+    must be preserved when we override the setting."""
+
+    def _no_follow(self):
+        from django.conf import settings
+
+        return [m.lower() for m in getattr(settings, 'WAGTAILTRANSFER_NO_FOLLOW_MODELS', [])]
+
+    def test_user_model_is_not_followed(self):
+        self.assertIn('auth.user', self._no_follow())
+
+    def test_package_defaults_are_preserved(self):
+        no_follow = self._no_follow()
+        self.assertIn('wagtailcore.page', no_follow)
+        self.assertIn('contenttypes.contenttype', no_follow)


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes to the wagtail-transfer integration, focusing on error handling, security, and UI compatibility with Wagtail 7.4. The most significant changes include: a patch that surfaces clear errors when the import receives a non-JSON HTTP response, an explicit allowlist for exportable models (including `wagtailcore.revision`), a setting to prevent following sensitive foreign keys (like `auth.user`), and a CSS fix for chooser pagination arrows in the admin. Comprehensive tests are added for all new behaviors.

**Wagtail-transfer error handling and robustness:**

* Added a patch to `ImportPlanner.add_json` that raises a clear `WagtailTransferImportError` if the source returns a non-JSON (e.g., HTTP error) response, including the start of the response body in the error message for easier debugging. [[1]](diffhunk://#diff-e5a866e58214af69e775db2d6ca8aebe203842bc705a1c4cf62246f3822d706aL4-R87) [[2]](diffhunk://#diff-e5a866e58214af69e775db2d6ca8aebe203842bc705a1c4cf62246f3822d706aL55-R110) [[3]](diffhunk://#diff-2783a9cefb71ecd3ef198fb47e21f2620f52327f8f38a474696766fcb3622b7bR24-R81)
* Updated and expanded tests to verify that non-JSON responses no longer raise opaque `JSONDecodeError`s and that the error message includes the actual response content.

**Security and data integrity:**

* Added `wagtailcore.revision` to the exportable model allowlist, ensuring page imports do not fail due to missing revision data. [[1]](diffhunk://#diff-cf6912936cfef7d1c76f180decc27b8e6d9639ed7f98af1d3d5ad818643419c4R31-R39) [[2]](diffhunk://#diff-4a7f39980b65681831f9b8a98aa4f5393b18ed6e543378a7fc491c2f8d0bea01R52-R80)
* Introduced and tested the `WAGTAILTRANSFER_NO_FOLLOW_MODELS` setting, explicitly preventing the importer from following references to sensitive models like `auth.user`, and ensuring package defaults are preserved. [[1]](diffhunk://#diff-7721f9594f70370e70e84e1d06db38d09fda8a34a9ff5250e35733b18941b659R285-R297) [[2]](diffhunk://#diff-4a7f39980b65681831f9b8a98aa4f5393b18ed6e543378a7fc491c2f8d0bea01R52-R80)

**Admin UI compatibility:**

* Added a global CSS file and Wagtail admin hook to fix the sizing of pagination arrows in the wagtail-transfer chooser, which were rendered incorrectly in Wagtail 7.4 due to changes in core icon styles. [[1]](diffhunk://#diff-9d1e5192e05a0a9b9e54ec1f68ffe0c5f11b8a2252c27b03769081d03c15c35fR1-R21) [[2]](diffhunk://#diff-683d955e9e8361e08cce3c0a3528e722d2cb0a0ad7dbaff0b347bbd936983d21R4-R21) [[3]](diffhunk://#diff-2e584ee05cbf57529ae69440ba2e9a3688a1a674d380a8f269a941eb370fd5a0R79-R94)

**Documentation and maintainability:**

* Improved in-code documentation for all patches, settings, and allowlist changes, clarifying the rationale and cross-referencing relevant upstream issues. [[1]](diffhunk://#diff-e5a866e58214af69e775db2d6ca8aebe203842bc705a1c4cf62246f3822d706aL4-R87) [[2]](diffhunk://#diff-cf6912936cfef7d1c76f180decc27b8e6d9639ed7f98af1d3d5ad818643419c4R31-R39) [[3]](diffhunk://#diff-7721f9594f70370e70e84e1d06db38d09fda8a34a9ff5250e35733b18941b659R285-R297)

These changes collectively make wagtail-transfer integration more robust, secure, and user-friendly for both developers and content editors.