### PR TITLE
Flexpage manual migration

### DIFF
--- a/authoring/drafts.py
+++ b/authoring/drafts.py
@@ -97,8 +97,15 @@ def _stream_block(field_name):
 
 def _reject_unknown_block_types(field_name, block, data):
     """Raise FlexValidationError if any entry in `data` has an unrecognised type."""
+    if not isinstance(data, (list, tuple)):
+        raise FlexValidationError({field_name: "Invalid StreamField data: expected a list of blocks."})
     known = set(block.child_blocks.keys())
-    unknown = [n.get("type") for n in data if n.get("type") not in known]
+    unknown = []
+    for n in data:
+        if not isinstance(n, dict) or "type" not in n:
+            raise FlexValidationError({field_name: "Invalid StreamField block: expected objects with a 'type' key."})
+        if n["type"] not in known:
+            unknown.append(n["type"])
     if unknown:
         raise FlexValidationError({
             field_name: f"Unknown block type(s): {unknown}. Allowed: {sorted(known)}."

--- a/authoring/drafts.py
+++ b/authoring/drafts.py
@@ -95,16 +95,21 @@ def _stream_block(field_name):
     return FlexPage._meta.get_field(field_name).stream_block
 
 
-def _clean(field_name, data):
-    """Build a StreamValue from stored-shape data and clean it. Returns the
-    cleaned StreamValue or raises FlexValidationError with per-block messages."""
-    block = _stream_block(field_name)
+def _reject_unknown_block_types(field_name, block, data):
+    """Raise FlexValidationError if any entry in `data` has an unrecognised type."""
     known = set(block.child_blocks.keys())
     unknown = [n.get("type") for n in data if n.get("type") not in known]
     if unknown:
         raise FlexValidationError({
             field_name: f"Unknown block type(s): {unknown}. Allowed: {sorted(known)}."
         })
+
+
+def _clean(field_name, data):
+    """Build a StreamValue from stored-shape data and clean it. Returns the
+    cleaned StreamValue or raises FlexValidationError with per-block messages."""
+    block = _stream_block(field_name)
+    _reject_unknown_block_types(field_name, block, data)
     value = block.to_python(data)
     try:
         return block.clean(value)
@@ -189,4 +194,36 @@ def update_flex_draft(*, page, title=None, layout_data=None, body_data=None, use
     page.save_revision(user=user)          # draft only; not published
     # Reflect unpublished changes without touching published fields.
     type(page).objects.filter(pk=page.pk).update(has_unpublished_changes=True)
+    return page, []
+
+
+def _to_value_shape_only(field_name, data):
+    """Validate block TYPES (reject unknown), build a StreamValue, but do NOT run
+    block.clean() — required-field enforcement is deferred to publish time."""
+    block = _stream_block(field_name)
+    _reject_unknown_block_types(field_name, block, data)
+    return block.to_python(data)
+
+
+def create_flex_draft_lenient(*, parent, title, slug, layout_data, body_data, user=None):
+    """Create a FlexPage draft from migrated content.
+
+    Unlike create_flex_draft: skips rich-text reference validation (references were
+    already blanked by the migration sanitizer) and defers required-field checks
+    (a blanked required chooser saves fine as a draft). Block SHAPE is still
+    validated. Never publishes.
+    """
+    layout_value = _to_value_shape_only("layout", layout_data or [])
+    body_value = _to_value_shape_only("body", body_data or [])
+
+    page = FlexPage(
+        title=title,
+        slug=slug,
+        layout=layout_value,
+        body=body_value,
+        live=False,
+        has_unpublished_changes=True,
+    )
+    parent.add_child(instance=page)
+    page.save_revision(user=user)
     return page, []

--- a/authoring/migration.py
+++ b/authoring/migration.py
@@ -6,6 +6,11 @@ links) cannot survive a move between environments, so we blank them while keepin
 the surrounding block/text/structure. The walk is driven by the real block
 definitions (same source-of-truth principle as authoring/drafts.py), so we never
 hardcode a fragile field-name list.
+
+Assumption: source and target environments share the same FlexPage block schema.
+Unknown block types are passed through unsanitized (their references would NOT be
+blanked), so this tool is intended for environments running the same deployed code —
+which is the case for dev/staging/prod of the same release.
 """
 import re
 from collections.abc import Sequence

--- a/authoring/migration.py
+++ b/authoring/migration.py
@@ -1,0 +1,93 @@
+# authoring/migration.py
+"""Turn a live FlexPage into a sanitized, import-ready payload.
+
+Cross-environment object references (images, documents, snippet choosers, page
+links) cannot survive a move between environments, so we blank them while keeping
+the surrounding block/text/structure. The walk is driven by the real block
+definitions (same source-of-truth principle as authoring/drafts.py), so we never
+hardcode a fragile field-name list.
+"""
+import re
+from collections.abc import Sequence
+
+from wagtail import blocks
+from wagtail.blocks import ChooserBlock
+from pages.models import FlexPage
+
+# Mirror the rich-text tag patterns used in authoring/drafts.py, but for removal.
+_PAGE_LINK_RE = re.compile(r'<a\b[^>]*\blinktype="page"[^>]*>(.*?)</a>', re.IGNORECASE | re.DOTALL)
+_IMAGE_EMBED_RE = re.compile(r'<embed\b[^>]*\bembedtype="image"[^>]*/?>', re.IGNORECASE)
+
+
+def _strip_richtext_refs(html):
+    """Unwrap page links to their inner text; remove image embeds."""
+    if not isinstance(html, str):
+        return html
+    html = _PAGE_LINK_RE.sub(r'\1', html)
+    html = _IMAGE_EMBED_RE.sub('', html)
+    return html
+
+
+def sanitize_block(block, raw_value):
+    """Recursively blank cross-env references in a stored-shape block value."""
+    if isinstance(block, ChooserBlock):
+        return None
+    if isinstance(block, (blocks.RichTextBlock, blocks.RawHTMLBlock)):
+        return _strip_richtext_refs(raw_value)
+    if isinstance(block, blocks.StructBlock):
+        if not isinstance(raw_value, dict):
+            return raw_value
+        return {
+            name: sanitize_block(child, raw_value[name])
+            for name, child in block.child_blocks.items()
+            if name in raw_value
+        }
+    if isinstance(block, blocks.StreamBlock):
+        return sanitize_raw_stream(block, raw_value)
+    if isinstance(block, blocks.ListBlock):
+        if isinstance(raw_value, str) or not isinstance(raw_value, Sequence):
+            return raw_value
+        out = []
+        for item in raw_value:
+            if isinstance(item, dict) and "value" in item:  # new list format
+                out.append({**item, "value": sanitize_block(block.child_block, item["value"])})
+            else:                                            # legacy bare-value format
+                out.append(sanitize_block(block.child_block, item))
+        return out
+    return raw_value
+
+
+def sanitize_raw_stream(stream_block, raw_data):
+    """Sanitize a StreamField's raw list of {type, value, id} children.
+
+    Accepts any non-string sequence (list, Wagtail's RawDataView, etc.) so
+    callers can pass `page.body.raw_data` directly without converting it.
+    """
+    if isinstance(raw_data, str) or not isinstance(raw_data, Sequence):
+        return raw_data
+    out = []
+    for node in raw_data:
+        child = stream_block.child_blocks.get(node.get("type"))
+        if child is None:
+            out.append(node)  # unknown type: leave for the importer to reject
+            continue
+        out.append({**node, "value": sanitize_block(child, node.get("value"))})
+    return out
+
+
+def build_export_payload(page):
+    """Live `title`/`slug`/`layout`/`body`, sanitized and import-shaped.
+
+    Reads the LIVE field values (not the latest draft revision). `raw_data` is the
+    stored {type, value, id} stream shape, which the import endpoint can ingest;
+    the public api_fields representation is rendered/serialized and is NOT
+    re-importable.
+    """
+    layout_block = FlexPage._meta.get_field("layout").stream_block
+    body_block = FlexPage._meta.get_field("body").stream_block
+    return {
+        "title": page.title,
+        "slug": page.slug,
+        "layout": sanitize_raw_stream(layout_block, page.layout.raw_data),
+        "body": sanitize_raw_stream(body_block, page.body.raw_data),
+    }

--- a/authoring/migration.py
+++ b/authoring/migration.py
@@ -37,11 +37,12 @@ def sanitize_block(block, raw_value):
     if isinstance(block, blocks.StructBlock):
         if not isinstance(raw_value, dict):
             return raw_value
-        return {
+        sanitized = {
             name: sanitize_block(child, raw_value[name])
             for name, child in block.child_blocks.items()
             if name in raw_value
         }
+        return {**raw_value, **sanitized}  # unknown keys pass through; known keys sanitized
     if isinstance(block, blocks.StreamBlock):
         return sanitize_raw_stream(block, raw_value)
     if isinstance(block, blocks.ListBlock):

--- a/authoring/tests/test_drafts.py
+++ b/authoring/tests/test_drafts.py
@@ -340,6 +340,35 @@ class PageLockEndpointTests(TestCase):
         self.assertEqual(resp.status_code, 409)
 
 
+from authoring.drafts import create_flex_draft_lenient
+
+
+class LenientDraftTests(TestCase):
+    def setUp(self):
+        root = Page.objects.get(depth=1)
+        self.home = page_models.RootPage(title="Home", slug="site-root")
+        root.add_child(instance=self.home)
+
+    def test_accepts_blanked_required_reference(self):
+        # body block whose value omits a normally-required nested field stands in
+        # for a blanked reference; lenient create must not raise on required checks.
+        page, warnings = create_flex_draft_lenient(
+            parent=self.home, title="L", slug="lenient",
+            layout_data=DEFAULT_LAYOUT, body_data=[],
+        )
+        self.assertFalse(page.live)
+        self.assertTrue(page.has_unpublished_changes)
+        self.assertEqual(page.title, "L")
+
+    def test_unknown_block_type_still_rejected(self):
+        with self.assertRaises(FlexValidationError):
+            create_flex_draft_lenient(
+                parent=self.home, title="Bad", slug="bad",
+                layout_data=DEFAULT_LAYOUT,
+                body_data=[{"type": "not_a_real_block", "value": "x"}],
+            )
+
+
 from wagtail.images.tests.utils import Image, get_test_image_file
 
 

--- a/authoring/tests/test_drafts.py
+++ b/authoring/tests/test_drafts.py
@@ -5,6 +5,16 @@ from pages import models as page_models
 from authoring.routing_rules import validate_page_location, RoutingError
 from django.contrib.auth import get_user_model
 from authoring.permissions import CanDraftFlexPages
+from authoring.drafts import (
+    validate_layout, validate_body, FlexValidationError,
+    create_flex_draft, update_flex_draft,
+    validate_rich_text_references, create_flex_draft_lenient,
+)
+from django.contrib.auth.models import AnonymousUser
+from rest_framework.test import APIClient
+from rest_framework.authtoken.models import Token
+from wagtail.images import get_image_model
+from wagtail.images.tests.utils import Image, get_test_image_file
 
 DEFAULT_LAYOUT = [{"type": "default", "value": {}}]
 LANDING_LAYOUT = [{"type": "landing", "value": {"nav_links": [], "show_give_now_button": True}}]
@@ -58,7 +68,6 @@ class PermissionTests(TestCase):
         return r
 
     def test_anonymous_denied(self):
-        from django.contrib.auth.models import AnonymousUser
         self.assertFalse(self.perm.has_permission(self._req(AnonymousUser()), None))
 
     def test_non_staff_denied(self):
@@ -68,11 +77,6 @@ class PermissionTests(TestCase):
     def test_staff_allowed(self):
         u = self.User.objects.create_user("staff", password="x", is_staff=True)
         self.assertTrue(self.perm.has_permission(self._req(u), None))
-
-
-from authoring.drafts import (
-    validate_layout, validate_body, FlexValidationError,
-)
 
 
 class LayoutValidationTests(TestCase):
@@ -103,9 +107,6 @@ class BodyValidationTests(TestCase):
         self.assertIn("not_a_block", str(ctx.exception))
 
 
-from authoring.drafts import create_flex_draft
-
-
 class CreateDraftTests(TestCase):
     def setUp(self):
         root = Page.objects.get(depth=1)
@@ -125,9 +126,6 @@ class CreateDraftTests(TestCase):
         self.assertTrue(page.has_unpublished_changes)
         self.assertIsNotNone(page.get_latest_revision())  # draft revision exists
         self.assertEqual(page.slug, "why-openstax")
-
-
-from authoring.drafts import update_flex_draft
 
 
 class UpdateDraftTests(TestCase):
@@ -159,10 +157,6 @@ class UpdateDraftTests(TestCase):
         latest = live.get_latest_revision_as_object()
         self.assertEqual(latest.title, "Draft Title")            # draft has the change
         self.assertIn("changed", str(latest.body))
-
-
-from rest_framework.test import APIClient
-from rest_framework.authtoken.models import Token
 
 
 class FlexDraftEndpointTests(TestCase):
@@ -259,10 +253,6 @@ class FlexDraftEndpointTests(TestCase):
         self.assertEqual(resp.status_code, 403)
 
 
-from authoring.drafts import validate_rich_text_references
-from wagtail.images import get_image_model
-
-
 class RichTextReferenceTests(TestCase):
     def setUp(self):
         root = Page.objects.get(depth=1)
@@ -291,7 +281,6 @@ class RichTextReferenceTests(TestCase):
 
     def test_valid_image_embed_passes(self):
         ImageModel = get_image_model()
-        from wagtail.images.tests.utils import get_test_image_file
         img = ImageModel.objects.create(title="Test img", file=get_test_image_file())
         body = self._section_with_html(f'<p><embed embedtype="image" id="{img.id}" alt="x" format="left"/></p>')
         validate_rich_text_references(body)  # should not raise
@@ -340,9 +329,6 @@ class PageLockEndpointTests(TestCase):
         self.assertEqual(resp.status_code, 409)
 
 
-from authoring.drafts import create_flex_draft_lenient
-
-
 class LenientDraftTests(TestCase):
     def setUp(self):
         root = Page.objects.get(depth=1)
@@ -350,15 +336,26 @@ class LenientDraftTests(TestCase):
         root.add_child(instance=self.home)
 
     def test_accepts_blanked_required_reference(self):
-        # body block whose value omits a normally-required nested field stands in
-        # for a blanked reference; lenient create must not raise on required checks.
+        # Approach: use a 'divider' block whose required 'image' sub-field is
+        # omitted. Strict create_flex_draft runs block.clean() and rejects it;
+        # lenient create_flex_draft_lenient skips clean() and accepts it.
+        DIVIDER_MISSING_IMAGE = [{"type": "divider", "value": {}}]
+
+        # Strict path must REJECT the missing-required-field block.
+        with self.assertRaises(FlexValidationError):
+            create_flex_draft(
+                parent=self.home, title="Strict", slug="lenient-strict",
+                layout_data=DEFAULT_LAYOUT, body_data=DIVIDER_MISSING_IMAGE,
+            )
+
+        # Lenient path must ACCEPT the same block and return a live=False draft.
         page, warnings = create_flex_draft_lenient(
-            parent=self.home, title="L", slug="lenient",
-            layout_data=DEFAULT_LAYOUT, body_data=[],
+            parent=self.home, title="Lenient", slug="lenient-ok",
+            layout_data=DEFAULT_LAYOUT, body_data=DIVIDER_MISSING_IMAGE,
         )
         self.assertFalse(page.live)
         self.assertTrue(page.has_unpublished_changes)
-        self.assertEqual(page.title, "L")
+        self.assertEqual(page.title, "Lenient")
 
     def test_unknown_block_type_still_rejected(self):
         with self.assertRaises(FlexValidationError):
@@ -367,9 +364,6 @@ class LenientDraftTests(TestCase):
                 layout_data=DEFAULT_LAYOUT,
                 body_data=[{"type": "not_a_real_block", "value": "x"}],
             )
-
-
-from wagtail.images.tests.utils import Image, get_test_image_file
 
 
 class ImageSearchTests(TestCase):

--- a/authoring/tests/test_migrate_script.py
+++ b/authoring/tests/test_migrate_script.py
@@ -1,0 +1,53 @@
+# authoring/tests/test_migrate_script.py
+import importlib.util
+import os
+from django.test import TestCase
+
+_SCRIPT = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
+    "scripts", "flex_migrate.py",
+)
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("flex_migrate", _SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class MigrateScriptTests(TestCase):
+    def test_assemble_import_body_injects_parent(self):
+        m = _load()
+        body = m.assemble_import_body({"title": "T", "slug": "s", "layout": [], "body": []}, 30)
+        self.assertEqual(body["parent_id"], 30)
+        self.assertEqual(body["title"], "T")
+
+    def test_run_migration_calls_export_then_import(self):
+        m = _load()
+        calls = {}
+
+        class Resp:
+            status_code = 200
+            def __init__(self, data): self._data = data
+            def json(self): return self._data
+            def raise_for_status(self): pass
+
+        def fake_get(url, headers=None):
+            calls["get_url"] = url
+            return Resp({"title": "T", "slug": "s", "layout": [], "body": []})
+
+        def fake_post(url, json=None, headers=None):
+            calls["post_url"] = url
+            calls["post_body"] = json
+            return Resp({"id": 123, "live": False, "edit_url": "/admin/pages/123/edit/"})
+
+        out = m.run_migration(
+            source_base="https://dev/x", source_token="D",
+            target_base="https://stg/x", target_token="S",
+            page_id=568, parent_id=30, http_get=fake_get, http_post=fake_post,
+        )
+        self.assertEqual(calls["get_url"], "https://dev/x/568/export/")
+        self.assertEqual(calls["post_url"], "https://stg/x/import/")
+        self.assertEqual(calls["post_body"]["parent_id"], 30)
+        self.assertEqual(out["id"], 123)

--- a/authoring/tests/test_migration.py
+++ b/authoring/tests/test_migration.py
@@ -46,6 +46,15 @@ class SanitizeNestedTests(TestCase):
         result = sanitize_block(block, raw)
         self.assertEqual(result[0]["value"], {"book": None, "label": "Bio"})
 
+    def test_struct_passes_through_unknown_keys(self):
+        block = blocks.StructBlock([
+            ("image", ImageChooserBlock(required=False)),
+        ])
+        raw = {"image": 88, "legacy_field": "stale"}
+        result = sanitize_block(block, raw)
+        self.assertIsNone(result["image"])           # known ref blanked
+        self.assertEqual(result["legacy_field"], "stale")  # unknown key kept
+
     def test_stream_blanks_top_level_image_block(self):
         stream = blocks.StreamBlock([
             ("image", ImageChooserBlock(required=False)),

--- a/authoring/tests/test_migration.py
+++ b/authoring/tests/test_migration.py
@@ -1,0 +1,90 @@
+# authoring/tests/test_migration.py
+from django.test import TestCase
+from wagtail import blocks
+from wagtail.images.blocks import ImageChooserBlock
+from wagtail.models import Page
+from wagtail.snippets.blocks import SnippetChooserBlock
+
+from pages import models as page_models
+from authoring.migration import sanitize_block, sanitize_raw_stream, build_export_payload
+
+
+class SanitizeLeafTests(TestCase):
+    def test_image_chooser_blanked_to_none(self):
+        self.assertIsNone(sanitize_block(ImageChooserBlock(required=False), 88))
+
+    def test_page_link_unwrapped_in_richtext(self):
+        block = blocks.RichTextBlock()
+        html = 'see <a linktype="page" id="12">the docs</a> now'
+        self.assertEqual(sanitize_block(block, html), 'see the docs now')
+
+    def test_image_embed_removed_in_richtext(self):
+        block = blocks.RichTextBlock()
+        html = 'before<embed embedtype="image" id="45" format="left"/>after'
+        self.assertEqual(sanitize_block(block, html), 'beforeafter')
+
+    def test_plain_charblock_untouched(self):
+        block = blocks.CharBlock()
+        self.assertEqual(sanitize_block(block, "Welcome"), "Welcome")
+
+
+class SanitizeNestedTests(TestCase):
+    def test_struct_with_nested_image_and_text(self):
+        block = blocks.StructBlock([
+            ("heading", blocks.CharBlock()),
+            ("image", ImageChooserBlock(required=False)),
+        ])
+        raw = {"heading": "Hi", "image": 88}
+        self.assertEqual(sanitize_block(block, raw), {"heading": "Hi", "image": None})
+
+    def test_list_of_structs_recurses(self):
+        block = blocks.ListBlock(blocks.StructBlock([
+            ("book", SnippetChooserBlock("snippets.Subject")),
+            ("label", blocks.CharBlock()),
+        ]))
+        raw = [{"type": "item", "id": "x", "value": {"book": 7, "label": "Bio"}}]
+        result = sanitize_block(block, raw)
+        self.assertEqual(result[0]["value"], {"book": None, "label": "Bio"})
+
+    def test_stream_blanks_top_level_image_block(self):
+        stream = blocks.StreamBlock([
+            ("image", ImageChooserBlock(required=False)),
+            ("para", blocks.CharBlock()),
+        ])
+        raw = [
+            {"type": "image", "id": "a", "value": 88},
+            {"type": "para", "id": "b", "value": "kept"},
+        ]
+        result = sanitize_raw_stream(stream, raw)
+        self.assertIsNone(result[0]["value"])
+        self.assertEqual(result[1]["value"], "kept")
+
+
+# Note: `paragraph` is not a real block key in FlexPage.body — actual top-level
+# block keys are: columns, divider, hero, html, section, tabbed_content.
+# `html` (RawHTMLBlock) is the top-level raw-HTML block used here because it holds
+# HTML content that may contain page-link tags. RawHTMLBlock is handled by
+# _strip_richtext_refs, identical to RichTextBlock, so sanitization logic is identical.
+DEFAULT_LAYOUT = [{"type": "default", "value": {}}]
+
+
+class ExportPayloadTests(TestCase):
+    def setUp(self):
+        root = Page.objects.get(depth=1)
+        self.home = page_models.RootPage(title="Home", slug="site-root")
+        root.add_child(instance=self.home)
+        self.page = page_models.FlexPage(
+            title="Sample", slug="sample",
+            layout=DEFAULT_LAYOUT,
+            body=[{"type": "html", "value": '<p>see <a linktype="page" id="999">x</a></p>'}],
+        )
+        self.home.add_child(instance=self.page)
+
+    def test_payload_shape_and_sanitization(self):
+        payload = build_export_payload(page_models.FlexPage.objects.get(id=self.page.id))
+        self.assertEqual(set(payload), {"title", "slug", "layout", "body"})
+        self.assertEqual(payload["title"], "Sample")
+        self.assertEqual(payload["slug"], "sample")
+        # the page link is unwrapped to its inner text
+        self.assertIn("see x", payload["body"][0]["value"])
+        self.assertNotIn("linktype", payload["body"][0]["value"])

--- a/authoring/tests/test_views_migration.py
+++ b/authoring/tests/test_views_migration.py
@@ -39,3 +39,48 @@ class ExportEndpointTests(TestCase):
         resp = self.client.get("/apps/cms/api/v2/pages/flex/999999/export/")
         self.assertEqual(resp.status_code, 404)
         self.assertIn("errors", resp.json())
+
+
+class ImportEndpointTests(TestCase):
+    def setUp(self):
+        root = Page.objects.get(depth=1)
+        self.home = page_models.RootPage(title="Home", slug="site-root")
+        root.add_child(instance=self.home)
+        self.staff = get_user_model().objects.create_user(
+            username="ed", password="x", is_staff=True, is_superuser=True,
+        )
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.staff)
+
+    def _body(self, **over):
+        payload = {
+            "parent_id": self.home.id,
+            "title": "Imported",
+            "slug": "imported",
+            "layout": DEFAULT_LAYOUT,
+            "body": [],
+        }
+        payload.update(over)
+        return payload
+
+    def test_imports_as_unpublished_draft(self):
+        resp = self.client.post(
+            "/apps/cms/api/v2/pages/flex/import/", self._body(), format="json",
+        )
+        self.assertEqual(resp.status_code, 201)
+        self.assertFalse(resp.json()["live"])
+        self.assertIn("edit_url", resp.json())
+
+    def test_unknown_parent_400(self):
+        resp = self.client.post(
+            "/apps/cms/api/v2/pages/flex/import/",
+            self._body(parent_id=999999), format="json",
+        )
+        self.assertEqual(resp.status_code, 400)
+
+    def test_unknown_block_type_400(self):
+        resp = self.client.post(
+            "/apps/cms/api/v2/pages/flex/import/",
+            self._body(body=[{"type": "not_a_block", "value": "x"}]), format="json",
+        )
+        self.assertEqual(resp.status_code, 400)

--- a/authoring/tests/test_views_migration.py
+++ b/authoring/tests/test_views_migration.py
@@ -97,3 +97,35 @@ class ImportEndpointTests(TestCase):
             self._body(parent_id="abc"), format="json",
         )
         self.assertEqual(resp.status_code, 400)
+
+
+class CreateEndpointParentIdTests(TestCase):
+    """Strict create endpoint (POST /apps/cms/api/v2/pages/flex/) parent_id edge cases."""
+
+    def setUp(self):
+        root = Page.objects.get(depth=1)
+        self.home = page_models.RootPage(title="Home", slug="site-root")
+        root.add_child(instance=self.home)
+        self.staff = get_user_model().objects.create_user(
+            username="ed_create", password="x", is_staff=True, is_superuser=True,
+        )
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.staff)
+
+    def _body(self, **over):
+        payload = {
+            "parent_id": self.home.id,
+            "title": "X",
+            "slug": "x",
+            "layout": DEFAULT_LAYOUT,
+            "body": [],
+        }
+        payload.update(over)
+        return payload
+
+    def test_non_integer_parent_400(self):
+        resp = self.client.post(
+            "/apps/cms/api/v2/pages/flex/",
+            self._body(parent_id="abc"), format="json",
+        )
+        self.assertEqual(resp.status_code, 400)

--- a/authoring/tests/test_views_migration.py
+++ b/authoring/tests/test_views_migration.py
@@ -84,3 +84,16 @@ class ImportEndpointTests(TestCase):
             self._body(body=[{"type": "not_a_block", "value": "x"}]), format="json",
         )
         self.assertEqual(resp.status_code, 400)
+
+    def test_unauthenticated_rejected(self):
+        from rest_framework.test import APIClient
+        anon = APIClient()
+        resp = anon.post("/apps/cms/api/v2/pages/flex/import/", self._body(), format="json")
+        self.assertIn(resp.status_code, (401, 403))
+
+    def test_non_integer_parent_400(self):
+        resp = self.client.post(
+            "/apps/cms/api/v2/pages/flex/import/",
+            self._body(parent_id="abc"), format="json",
+        )
+        self.assertEqual(resp.status_code, 400)

--- a/authoring/tests/test_views_migration.py
+++ b/authoring/tests/test_views_migration.py
@@ -30,10 +30,12 @@ class ExportEndpointTests(TestCase):
         self.client.force_authenticate(user=self.staff)
         resp = self.client.get(f"/apps/cms/api/v2/pages/flex/{self.page.id}/export/")
         self.assertEqual(resp.status_code, 200)
-        self.assertEqual(set(resp.json()), {"title", "slug", "layout", "body"})
-        self.assertEqual(resp.json()["slug"], "sample")
+        data = resp.json()
+        self.assertEqual(set(data), {"title", "slug", "layout", "body"})
+        self.assertEqual(data["slug"], "sample")
 
     def test_unknown_page_404(self):
         self.client.force_authenticate(user=self.staff)
         resp = self.client.get("/apps/cms/api/v2/pages/flex/999999/export/")
         self.assertEqual(resp.status_code, 404)
+        self.assertIn("errors", resp.json())

--- a/authoring/tests/test_views_migration.py
+++ b/authoring/tests/test_views_migration.py
@@ -1,0 +1,39 @@
+# authoring/tests/test_views_migration.py
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from rest_framework.test import APIClient
+from wagtail.models import Page
+from pages import models as page_models
+
+DEFAULT_LAYOUT = [{"type": "default", "value": {}}]
+
+
+class ExportEndpointTests(TestCase):
+    def setUp(self):
+        root = Page.objects.get(depth=1)
+        self.home = page_models.RootPage(title="Home", slug="site-root")
+        root.add_child(instance=self.home)
+        self.page = page_models.FlexPage(
+            title="Sample", slug="sample", layout=DEFAULT_LAYOUT, body=[],
+        )
+        self.home.add_child(instance=self.page)
+        self.staff = get_user_model().objects.create_user(
+            username="ed", password="x", is_staff=True,
+        )
+        self.client = APIClient()
+
+    def test_requires_auth(self):
+        resp = self.client.get(f"/apps/cms/api/v2/pages/flex/{self.page.id}/export/")
+        self.assertIn(resp.status_code, (401, 403))
+
+    def test_exports_import_shaped_payload(self):
+        self.client.force_authenticate(user=self.staff)
+        resp = self.client.get(f"/apps/cms/api/v2/pages/flex/{self.page.id}/export/")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(set(resp.json()), {"title", "slug", "layout", "body"})
+        self.assertEqual(resp.json()["slug"], "sample")
+
+    def test_unknown_page_404(self):
+        self.client.force_authenticate(user=self.staff)
+        resp = self.client.get("/apps/cms/api/v2/pages/flex/999999/export/")
+        self.assertEqual(resp.status_code, 404)

--- a/authoring/tests/test_views_migration.py
+++ b/authoring/tests/test_views_migration.py
@@ -18,7 +18,7 @@ class ExportEndpointTests(TestCase):
         )
         self.home.add_child(instance=self.page)
         self.staff = get_user_model().objects.create_user(
-            username="ed", password="x", is_staff=True,
+            username="exporter", password="x", is_staff=True, is_superuser=True,
         )
         self.client = APIClient()
 
@@ -33,6 +33,15 @@ class ExportEndpointTests(TestCase):
         data = resp.json()
         self.assertEqual(set(data), {"title", "slug", "layout", "body"})
         self.assertEqual(data["slug"], "sample")
+
+    def test_staff_without_edit_permission_forbidden(self):
+        plain_staff = get_user_model().objects.create_user(
+            username="plain-staff", password="x", is_staff=True,
+        )
+        client = APIClient()
+        client.force_authenticate(user=plain_staff)
+        resp = client.get(f"/apps/cms/api/v2/pages/flex/{self.page.id}/export/")
+        self.assertEqual(resp.status_code, 403)
 
     def test_unknown_page_404(self):
         self.client.force_authenticate(user=self.staff)

--- a/authoring/tests/test_views_migration.py
+++ b/authoring/tests/test_views_migration.py
@@ -8,26 +8,40 @@ from pages import models as page_models
 DEFAULT_LAYOUT = [{"type": "default", "value": {}}]
 
 
-class ExportEndpointTests(TestCase):
+class MigrationViewTestBase(TestCase):
+    """Shared fixtures for migration endpoint tests.
+
+    Provides:
+      self.home   — RootPage added to the Wagtail tree root
+      self.staff  — superuser staff user (username "migrator")
+      self.client — APIClient force-authenticated as self.staff
+    """
+
     def setUp(self):
         root = Page.objects.get(depth=1)
         self.home = page_models.RootPage(title="Home", slug="site-root")
         root.add_child(instance=self.home)
+        self.staff = get_user_model().objects.create_user(
+            username="migrator", password="x", is_staff=True, is_superuser=True,
+        )
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.staff)
+
+
+class ExportEndpointTests(MigrationViewTestBase):
+    def setUp(self):
+        super().setUp()
         self.page = page_models.FlexPage(
             title="Sample", slug="sample", layout=DEFAULT_LAYOUT, body=[],
         )
         self.home.add_child(instance=self.page)
-        self.staff = get_user_model().objects.create_user(
-            username="exporter", password="x", is_staff=True, is_superuser=True,
-        )
-        self.client = APIClient()
 
     def test_requires_auth(self):
-        resp = self.client.get(f"/apps/cms/api/v2/pages/flex/{self.page.id}/export/")
+        anon = APIClient()
+        resp = anon.get(f"/apps/cms/api/v2/pages/flex/{self.page.id}/export/")
         self.assertIn(resp.status_code, (401, 403))
 
     def test_exports_import_shaped_payload(self):
-        self.client.force_authenticate(user=self.staff)
         resp = self.client.get(f"/apps/cms/api/v2/pages/flex/{self.page.id}/export/")
         self.assertEqual(resp.status_code, 200)
         data = resp.json()
@@ -44,23 +58,12 @@ class ExportEndpointTests(TestCase):
         self.assertEqual(resp.status_code, 403)
 
     def test_unknown_page_404(self):
-        self.client.force_authenticate(user=self.staff)
         resp = self.client.get("/apps/cms/api/v2/pages/flex/999999/export/")
         self.assertEqual(resp.status_code, 404)
         self.assertIn("errors", resp.json())
 
 
-class ImportEndpointTests(TestCase):
-    def setUp(self):
-        root = Page.objects.get(depth=1)
-        self.home = page_models.RootPage(title="Home", slug="site-root")
-        root.add_child(instance=self.home)
-        self.staff = get_user_model().objects.create_user(
-            username="ed", password="x", is_staff=True, is_superuser=True,
-        )
-        self.client = APIClient()
-        self.client.force_authenticate(user=self.staff)
-
+class ImportEndpointTests(MigrationViewTestBase):
     def _body(self, **over):
         payload = {
             "parent_id": self.home.id,
@@ -95,7 +98,6 @@ class ImportEndpointTests(TestCase):
         self.assertEqual(resp.status_code, 400)
 
     def test_unauthenticated_rejected(self):
-        from rest_framework.test import APIClient
         anon = APIClient()
         resp = anon.post("/apps/cms/api/v2/pages/flex/import/", self._body(), format="json")
         self.assertIn(resp.status_code, (401, 403))
@@ -108,18 +110,8 @@ class ImportEndpointTests(TestCase):
         self.assertEqual(resp.status_code, 400)
 
 
-class CreateEndpointParentIdTests(TestCase):
+class CreateEndpointParentIdTests(MigrationViewTestBase):
     """Strict create endpoint (POST /apps/cms/api/v2/pages/flex/) parent_id edge cases."""
-
-    def setUp(self):
-        root = Page.objects.get(depth=1)
-        self.home = page_models.RootPage(title="Home", slug="site-root")
-        root.add_child(instance=self.home)
-        self.staff = get_user_model().objects.create_user(
-            username="ed_create", password="x", is_staff=True, is_superuser=True,
-        )
-        self.client = APIClient()
-        self.client.force_authenticate(user=self.staff)
 
     def _body(self, **over):
         payload = {

--- a/authoring/urls.py
+++ b/authoring/urls.py
@@ -1,9 +1,10 @@
 from django.urls import path
 
-from authoring.views import FlexPageDraftView, FlexPageExportView
+from authoring.views import FlexPageDraftView, FlexPageExportView, FlexPageImportView
 
 urlpatterns = [
     path('', FlexPageDraftView.as_view(), name='flex-draft-create'),
+    path('import/', FlexPageImportView.as_view(), name='flex-import'),
     path('<int:page_id>/export/', FlexPageExportView.as_view(), name='flex-export'),
     path('<int:page_id>/', FlexPageDraftView.as_view(), name='flex-draft-update'),
 ]

--- a/authoring/urls.py
+++ b/authoring/urls.py
@@ -1,8 +1,9 @@
 from django.urls import path
 
-from authoring.views import FlexPageDraftView
+from authoring.views import FlexPageDraftView, FlexPageExportView
 
 urlpatterns = [
     path('', FlexPageDraftView.as_view(), name='flex-draft-create'),
+    path('<int:page_id>/export/', FlexPageExportView.as_view(), name='flex-export'),
     path('<int:page_id>/', FlexPageDraftView.as_view(), name='flex-draft-update'),
 ]

--- a/authoring/views.py
+++ b/authoring/views.py
@@ -107,7 +107,7 @@ class FlexPageImportView(APIView):
         data = request.data
         try:
             parent = Page.objects.get(id=data["parent_id"]).specific
-        except (KeyError, Page.DoesNotExist):
+        except (KeyError, ValueError, Page.DoesNotExist):
             return Response({"errors": {"parent_id": "Unknown or missing parent_id."}},
                             status=status.HTTP_400_BAD_REQUEST)
 

--- a/authoring/views.py
+++ b/authoring/views.py
@@ -37,7 +37,7 @@ class FlexPageDraftView(APIView):
         data = request.data
         try:
             parent = Page.objects.get(id=data["parent_id"]).specific
-        except (KeyError, Page.DoesNotExist):
+        except (KeyError, ValueError, Page.DoesNotExist):
             return Response({"errors": {"parent_id": "Unknown or missing parent_id."}},
                             status=status.HTTP_400_BAD_REQUEST)
 

--- a/authoring/views.py
+++ b/authoring/views.py
@@ -145,4 +145,7 @@ class FlexPageExportView(APIView):
         except FlexPage.DoesNotExist:
             return Response({"errors": {"page_id": "Unknown FlexPage."}},
                             status=status.HTTP_404_NOT_FOUND)
+        if not page.permissions_for_user(request.user).can_edit():
+            return Response({"errors": {"page_id": "You cannot export this page."}},
+                            status=status.HTTP_403_FORBIDDEN)
         return Response(build_export_payload(page), status=status.HTTP_200_OK)

--- a/authoring/views.py
+++ b/authoring/views.py
@@ -9,7 +9,7 @@ from wagtail.models import Page
 
 from pages.models import FlexPage
 from authoring.permissions import CanDraftFlexPages
-from authoring.drafts import create_flex_draft, update_flex_draft, FlexValidationError, PageLockedError
+from authoring.drafts import create_flex_draft, update_flex_draft, create_flex_draft_lenient, FlexValidationError, PageLockedError
 from authoring.routing_rules import validate_page_location, RoutingError
 from authoring.migration import build_export_payload
 
@@ -91,6 +91,47 @@ class FlexPageDraftView(APIView):
                 status=status.HTTP_409_CONFLICT,
             )
         return Response(_review_payload(page, []), status=status.HTTP_200_OK)
+
+
+class FlexPageImportView(APIView):
+    """POST migrated FlexPage JSON as an unpublished draft (lenient validation).
+
+    Mirrors the create flow's parent/routing/permission checks, but uses
+    create_flex_draft_lenient: references are assumed pre-blanked and required
+    fields are deferred to publish time.
+    """
+    authentication_classes = [TokenAuthentication]
+    permission_classes = [CanDraftFlexPages]
+
+    def post(self, request):
+        data = request.data
+        try:
+            parent = Page.objects.get(id=data["parent_id"]).specific
+        except (KeyError, Page.DoesNotExist):
+            return Response({"errors": {"parent_id": "Unknown or missing parent_id."}},
+                            status=status.HTTP_400_BAD_REQUEST)
+
+        if not parent.permissions_for_user(request.user).can_add_subpage():
+            return Response({"errors": {"parent_id": "You cannot add pages here."}},
+                            status=status.HTTP_403_FORBIDDEN)
+
+        try:
+            slug, routing_warnings = validate_page_location(parent, data.get("slug", ""))
+        except RoutingError:
+            return Response({"errors": {"slug": "Invalid page location or slug."}},
+                            status=status.HTTP_400_BAD_REQUEST)
+
+        try:
+            page, _ = create_flex_draft_lenient(
+                parent=parent, title=data.get("title", ""), slug=slug,
+                layout_data=data.get("layout"), body_data=data.get("body", []),
+                user=request.user,
+            )
+        except FlexValidationError as exc:
+            return Response({"errors": exc.errors}, status=status.HTTP_400_BAD_REQUEST)
+
+        return Response(_review_payload(page, routing_warnings),
+                        status=status.HTTP_201_CREATED)
 
 
 class FlexPageExportView(APIView):

--- a/authoring/views.py
+++ b/authoring/views.py
@@ -11,6 +11,7 @@ from pages.models import FlexPage
 from authoring.permissions import CanDraftFlexPages
 from authoring.drafts import create_flex_draft, update_flex_draft, FlexValidationError, PageLockedError
 from authoring.routing_rules import validate_page_location, RoutingError
+from authoring.migration import build_export_payload
 
 
 def _review_payload(page, warnings):
@@ -90,3 +91,17 @@ class FlexPageDraftView(APIView):
                 status=status.HTTP_409_CONFLICT,
             )
         return Response(_review_payload(page, []), status=status.HTTP_200_OK)
+
+
+class FlexPageExportView(APIView):
+    """GET a FlexPage's LIVE content as sanitized, import-ready JSON."""
+    authentication_classes = [TokenAuthentication]
+    permission_classes = [CanDraftFlexPages]
+
+    def get(self, request, page_id):
+        try:
+            page = FlexPage.objects.get(id=page_id)
+        except FlexPage.DoesNotExist:
+            return Response({"errors": {"page_id": "Unknown FlexPage."}},
+                            status=status.HTTP_404_NOT_FOUND)
+        return Response(build_export_payload(page), status=status.HTTP_200_OK)

--- a/docs/api/flex-migration.md
+++ b/docs/api/flex-migration.md
@@ -1,0 +1,209 @@
+# FlexPage Migration API (Stopgap)
+
+Export a `FlexPage`'s live content from one CMS environment and import it as an
+**unpublished draft** on another — so an editor can re-add blanked references and
+publish in the Wagtail admin.
+
+> **Why this exists:** `wagtail-transfer` requires environments to be re-seeded from
+> prod and fully pre-seeded before it can move pages. Until that setup is ready, this
+> two-endpoint HTTP round-trip is the supported path for moving FlexPages between
+> dev → staging → prod.
+>
+> **What this does NOT replace:** creating and editing drafts via the agent authoring
+> API (`POST /apps/cms/api/v2/pages/flex/` and `PATCH …/<id>/`). Those endpoints use
+> strict reference validation and are documented in `docs/api/flex-draft-save.md`.
+
+## Auth
+
+Both endpoints require a DRF token for a **staff** CMS user on the respective
+environment:
+
+```
+Authorization: Token <token>
+```
+
+Mint a token for a staff user (one-time, server side):
+
+```bash
+python3 manage.py drf_create_token <username>
+```
+
+- Only staff users with Wagtail add rights qualify. Superusers always qualify.
+- Missing or insufficient credentials: `401` / `403`.
+
+## Export — `GET /apps/cms/api/v2/pages/flex/<id>/export/`
+
+Reads the page's **live** field values (not the latest draft revision) and returns
+them sanitized and import-ready. The sanitizer blanks all cross-environment object
+references (see [Reference blanking](#reference-blanking)) while preserving all text,
+structure, and config.
+
+### Response
+
+**`200`:**
+
+```jsonc
+{
+  "title": "Why OpenStax Works",
+  "slug": "why-openstax-works",
+  "layout": [{ "type": "default", "value": {} }],
+  "body": [
+    { "type": "html", "id": "abc123", "value": "<p>Great for students</p>" }
+    // chooser block values (images, snippets, etc.) are null here — blanked by sanitizer
+  ]
+}
+```
+
+The four fields match the import endpoint's request body exactly. Pass this JSON
+directly to the import endpoint (adding `parent_id`).
+
+**`404`:**
+
+```jsonc
+{ "errors": { "page_id": "Unknown FlexPage." } }
+```
+
+Returned when the `id` does not exist or does not belong to a FlexPage.
+
+## Import — `POST /apps/cms/api/v2/pages/flex/import/`
+
+Creates an **unpublished draft** from migrated FlexPage JSON. Uses lenient
+validation: block structure is checked (unknown block types → `400`), but
+required-field checks and rich-text reference checks are **deferred to publish
+time** (because the sanitizer blanks references, and a blanked chooser saves fine
+as a draft).
+
+Routing rules are the same as the regular create endpoint: reserved slugs are
+rejected, only `RootPage` parents are allowed, and slug collisions are suffixed with
+a warning.
+
+### Request
+
+```jsonc
+{
+  "parent_id": 30,                              // REQUIRED. Must be the site root (RootPage) on the TARGET env.
+  "title": "Why OpenStax Works",
+  "slug": "why-openstax-works",
+  "layout": [{ "type": "default", "value": {} }],
+  "body": [ /* sanitized body from the export */ ]
+}
+```
+
+`parent_id` must be an integer (the page id of the target `RootPage`).
+A missing, non-integer, or unknown value returns `400`.
+
+### Response
+
+**`201` — draft created:**
+
+```jsonc
+{
+  "id": 42,
+  "slug": "why-openstax-works",
+  "live": false,           // ALWAYS false — never auto-published
+  "edit_url": "/admin/pages/42/edit/",
+  "preview_url": "/admin/pages/42/edit/preview/",
+  "warnings": []           // non-empty if the slug was suffixed due to collision
+}
+```
+
+## Reference blanking
+
+Cross-environment object references cannot survive a move between environments
+because images, documents, snippets, and pages have different database ids in each
+environment. The sanitizer blanks them while keeping everything else.
+
+| Content | What happens |
+|---|---|
+| **Text / HTML / structure / config** | Preserved as-is |
+| **Chooser blocks** (image, document, snippet, page, book-list, FAQ) | Set to `null` |
+| **Rich-text page links** (`<a linktype="page">`) | Unwrapped to their inner text |
+| **Rich-text image embeds** (`<embed embedtype="image">`) | Removed entirely |
+
+The sanitizer is driven by the actual FlexPage block definitions (same
+source-of-truth approach as the authoring service layer), so it handles nested
+choosers inside `StructBlock`, `StreamBlock`, and `ListBlock` without a hardcoded
+field-name list.
+
+### After import: required human steps
+
+The import **never publishes**. Before the page is ready to go live, an editor must:
+
+1. Open the draft in the Wagtail admin (`edit_url` from the import response).
+2. Re-add all blanked references: images, document links, snippet choosers, and
+   rich-text page links.
+3. Review all content for correctness in the target environment.
+4. Publish the page from the Wagtail admin.
+
+## Error shapes
+
+```jsonc
+// 400 — parent missing, non-integer, or not found
+{ "errors": { "parent_id": "Unknown or missing parent_id." } }
+
+// 400 — reserved slug
+{ "errors": { "slug": "Invalid page location or slug." } }
+
+// 400 — unknown block type in body or layout
+{ "errors": { "body": "Unknown block type(s): ['not_a_block']. Allowed: [...]." } }
+
+// 401 / 403 — missing or insufficient credentials
+// 404 — id does not exist or is not a FlexPage (export endpoint)
+```
+
+Slug collision is NOT a hard error — the draft is created with a numeric suffix
+(`-1`, `-2`, …) and a `slug_collision` warning is returned in the `warnings` array:
+
+```jsonc
+"warnings": [{
+  "code": "slug_collision",
+  "message": "A page with slug 'why-openstax-works' already exists in the site tree. Created as 'why-openstax-works-1' instead. …",
+  "existing_page_id": 17,
+  "existing_page_edit_url": "/admin/pages/17/edit/"
+}]
+```
+
+When you see this, you almost certainly want to open the existing page instead.
+
+## `flex_migrate.py` — CLI round-trip
+
+`scripts/flex_migrate.py` runs the full export→import round-trip in one command.
+It has no CMS dependencies and runs from any machine with `requests` installed.
+
+```bash
+python scripts/flex_migrate.py \
+  --page-id 568 \
+  --parent-id 30 \
+  --source  https://dev.openstax.org/apps/cms/api/v2/pages/flex \
+  --source-token "$DEV_TOKEN" \
+  --target  https://staging.openstax.org/apps/cms/api/v2/pages/flex \
+  --target-token "$STG_TOKEN"
+```
+
+On success it prints the new draft id and the admin edit URL:
+
+```
+Imported as draft id=42 (live=False).
+Open and publish: /admin/pages/42/edit/
+```
+
+HTTP errors (non-2xx responses) are printed to stderr with the status code and
+response body; the script exits with code `1`.
+
+### Flags
+
+| Flag | Required | Description |
+|---|---|---|
+| `--page-id` | Yes | Id of the FlexPage on the **source** environment |
+| `--parent-id` | Yes | Id of the parent `RootPage` on the **target** environment |
+| `--source` | Yes | Source flex API base URL (no trailing slash) |
+| `--source-token` | Yes | Staff API token for the source environment |
+| `--target` | Yes | Target flex API base URL (no trailing slash) |
+| `--target-token` | Yes | Staff API token for the target environment |
+
+## Guarantees
+
+- The import endpoint **never publishes**. `live` is always `false` on the returned
+  page; the live version on the target environment is never touched.
+- A human reviews all content and re-adds blanked references before publishing.
+- The script moves **one page at a time** — run it once per `--page-id`.

--- a/docs/api/flex-migration.md
+++ b/docs/api/flex-migration.md
@@ -68,10 +68,10 @@ Returned when the `id` does not exist or does not belong to a FlexPage.
 ## Import — `POST /apps/cms/api/v2/pages/flex/import/`
 
 Creates an **unpublished draft** from migrated FlexPage JSON. Uses lenient
-validation: block structure is checked (unknown block types → `400`), but
-required-field checks and rich-text reference checks are **deferred to publish
-time** (because the sanitizer blanks references, and a blanked chooser saves fine
-as a draft).
+validation: block **types** are checked (unknown block types → `400`), but layout
+cardinality (exactly one `default`/`landing` block), required-field checks, and
+rich-text reference checks are **deferred to publish time** (because the sanitizer
+blanks references, and a blanked chooser saves fine as a draft).
 
 Routing rules are the same as the regular create endpoint: reserved slugs are
 rejected, only `RootPage` parents are allowed, and slug collisions are suffixed with
@@ -144,8 +144,9 @@ The import **never publishes**. Before the page is ready to go live, an editor m
 // 400 — reserved slug
 { "errors": { "slug": "Invalid page location or slug." } }
 
-// 400 — unknown block type in body or layout
+// 400 — unknown block type (the key is the field that carried it: "body" or "layout")
 { "errors": { "body": "Unknown block type(s): ['not_a_block']. Allowed: [...]." } }
+{ "errors": { "layout": "Unknown block type(s): ['not_a_block']. Allowed: [...]." } }
 
 // 401 / 403 — missing or insufficient credentials
 // 404 — id does not exist or is not a FlexPage (export endpoint)

--- a/scripts/flex_migrate.py
+++ b/scripts/flex_migrate.py
@@ -52,9 +52,12 @@ def main(argv=None):
         )
     except requests.HTTPError as exc:
         resp = exc.response
-        print(f"HTTP {resp.status_code} from {resp.url}\n{resp.text}", file=sys.stderr)
+        if resp is None:
+            print(f"HTTP error (no response): {exc}", file=sys.stderr)
+        else:
+            print(f"HTTP {resp.status_code} from {resp.url}\n{resp.text}", file=sys.stderr)
         return 1
-    print(f"Imported as draft id={result['id']} (live={result['live']}).")
+    print(f"Imported as draft id={result.get('id')} (live={result.get('live', '?')}).")
     print(f"Open and publish: {result.get('edit_url', '(see admin)')}")
     return 0
 

--- a/scripts/flex_migrate.py
+++ b/scripts/flex_migrate.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Move one FlexPage's live content between OpenStax CMS environments over HTTP.
+
+Exports the page's live, sanitized layout/body from the source env and imports it
+as an unpublished draft on the target env. You then re-add images/links and publish
+in the Wagtail admin. Requires a staff API token on each environment.
+
+Example:
+    python scripts/flex_migrate.py --page-id 568 --parent-id 30 \
+      --source https://dev.openstax.org/apps/cms/api/v2/pages/flex --source-token "$DEV_TOKEN" \
+      --target https://staging.openstax.org/apps/cms/api/v2/pages/flex --target-token "$STG_TOKEN"
+"""
+import argparse
+import sys
+
+
+def assemble_import_body(export_json, parent_id):
+    return {**export_json, "parent_id": parent_id}
+
+
+def run_migration(*, source_base, source_token, target_base, target_token,
+                  page_id, parent_id, http_get, http_post):
+    src = source_base.rstrip("/")
+    tgt = target_base.rstrip("/")
+    get_resp = http_get(f"{src}/{page_id}/export/",
+                        headers={"Authorization": f"Token {source_token}"})
+    get_resp.raise_for_status()
+    body = assemble_import_body(get_resp.json(), parent_id)
+    post_resp = http_post(f"{tgt}/import/", json=body,
+                          headers={"Authorization": f"Token {target_token}"})
+    post_resp.raise_for_status()
+    return post_resp.json()
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser(description="Migrate a FlexPage between CMS environments.")
+    p.add_argument("--page-id", type=int, required=True)
+    p.add_argument("--parent-id", type=int, required=True, help="Parent page id on the TARGET env.")
+    p.add_argument("--source", required=True, help="Source flex API base URL.")
+    p.add_argument("--source-token", required=True)
+    p.add_argument("--target", required=True, help="Target flex API base URL.")
+    p.add_argument("--target-token", required=True)
+    args = p.parse_args(argv)
+
+    import requests  # imported here so the testable helpers need no network dep
+    try:
+        result = run_migration(
+            source_base=args.source, source_token=args.source_token,
+            target_base=args.target, target_token=args.target_token,
+            page_id=args.page_id, parent_id=args.parent_id,
+            http_get=requests.get, http_post=requests.post,
+        )
+    except requests.HTTPError as exc:
+        resp = exc.response
+        print(f"HTTP {resp.status_code} from {resp.url}\n{resp.text}", file=sys.stderr)
+        return 1
+    print(f"Imported as draft id={result['id']} (live={result['live']}).")
+    print(f"Open and publish: {result.get('edit_url', '(see admin)')}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
This pull request introduces a new migration/export/import system for FlexPage content, enabling safe cross-environment page transfers by sanitizing references and providing a lenient draft creation mode. The changes include new logic for blanking out non-portable references, new endpoints and tests for export/import, and updates to validation and draft creation to support migration workflows.

**Migration and Export/Import Functionality**

* Added `authoring/migration.py` to provide functions for sanitizing FlexPage content by blanking out cross-environment references (such as images, documents, snippet choosers, and page links), and for building an export-ready payload. 
* Added comprehensive tests for the migration logic in `authoring/tests/test_migration.py`, covering the sanitization of leaf, nested, and stream blocks, as well as the export payload structure. 
* Introduced `authoring/tests/test_views_migration.py` to test the new export and import API endpoints, ensuring correct authentication, payload shape, error handling, and draft creation behavior. 
* Added `authoring/tests/test_migrate_script.py` to test the migration script that orchestrates export from a source and import into a target environment. 

**Draft Creation and Validation Enhancements**

* Added a lenient draft creation function `create_flex_draft_lenient` in `authoring/drafts.py` that skips strict required-field and reference validation, allowing drafts with blanked required fields to be created for migration purposes.
* Refactored validation logic to separate block type validation (`_reject_unknown_block_types`) from block cleaning, ensuring unknown block types are always rejected, but required field checks can be deferred in lenient mode.
* Added tests for lenient draft creation, confirming that drafts with missing required references are accepted only in the lenient path, and unknown block types are still rejected. 

**Test Suite Maintenance**

* Consolidated and cleaned up imports in `authoring/tests/test_drafts.py` to remove redundancy and improve clarity. 

These changes collectively provide a robust foundation for migrating FlexPage content between environments, with strong validation, sanitization, and test coverage.