### PR TITLE
Drop orphaned oxmenus component_key/region columns

### DIFF
--- a/oxmenus/migrations/0006_drop_orphan_component_key_region.py
+++ b/oxmenus/migrations/0006_drop_orphan_component_key_region.py
@@ -8,8 +8,9 @@ from django.db import migrations
 # Drop them. IF EXISTS keeps this a no-op on databases that never received
 # those columns (fresh installs, CI, prod).
 DROP_ORPHAN_COLUMNS = """
-ALTER TABLE oxmenus_menus DROP COLUMN IF EXISTS component_key;
-ALTER TABLE oxmenus_menus DROP COLUMN IF EXISTS region;
+ALTER TABLE oxmenus_menus
+    DROP COLUMN IF EXISTS component_key,
+    DROP COLUMN IF EXISTS region;
 """
 
 

--- a/oxmenus/migrations/0006_drop_orphan_component_key_region.py
+++ b/oxmenus/migrations/0006_drop_orphan_component_key_region.py
@@ -1,0 +1,24 @@
+from django.db import migrations
+
+
+# The `component_key` and `region` columns were added to oxmenus_menus by an
+# older PR (core-oxmenu-nav-regions) that was thrown away before merging. The
+# columns are NOT NULL with no DB default, so they were left orphaned on the
+# dev database and reject every insert from the current (column-less) model.
+# Drop them. IF EXISTS keeps this a no-op on databases that never received
+# those columns (fresh installs, CI, prod).
+DROP_ORPHAN_COLUMNS = """
+ALTER TABLE oxmenus_menus DROP COLUMN IF EXISTS component_key;
+ALTER TABLE oxmenus_menus DROP COLUMN IF EXISTS region;
+"""
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("oxmenus", "0005_alter_menus_options_menus_sort_order_and_more"),
+    ]
+
+    operations = [
+        migrations.RunSQL(DROP_ORPHAN_COLUMNS, reverse_sql=migrations.RunSQL.noop),
+    ]


### PR DESCRIPTION
## Problem

Saving an oxmenus menu item on **dev** fails with:

> `IntegrityError: null value in column "component_key" of relation "oxmenus_menus" violates not-null constraint`

## Root cause

An older, discarded PR (`core-oxmenu-nav-regions`) added `component_key` and `region` to `oxmenus_menus` — both `NOT NULL` with no DB-level default — and its migrations were applied to the dev database before the branch was thrown away. The current `Menus` model has neither field, so every insert from the snippet admin omits them and Postgres rejects the row. (`region` is the same kind of orphan and would fail the next save once `component_key` was past.)

## Fix

A single migration that drops both columns with `DROP COLUMN IF EXISTS`, so it actually drops them on dev but is a clean no-op on databases that never received them (CI, prod, fresh installs).

## Verification

- `migrate --plan` lists `oxmenus.0006`
- `makemigrations --check` → no model drift (pure SQL, no model fields touched)
- `oxmenus` test suite passes 6/6 (confirms the `IF EXISTS` no-op path on a fresh DB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)