### PR TITLE
Upgrade posthog SDK 3.25.0 -> 7.21.1

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -23,7 +23,7 @@ llm==0.31
 llm-anthropic==0.25.1
 mapbox==0.18.1
 pgvector==0.4.2
-posthog>=3.7,<4.0
+posthog==7.21.1
 Pillow==12.2.0
 psycopg2
 python-dotenv==1.2.2


### PR DESCRIPTION
## Why

PostHog's SDK Health check flags our Python SDK as outdated: we were on 3.25.0 (April 2025) while the latest is 7.21.x. The old pin `posthog>=3.7,<4.0` capped us at 3.25.0 forever — it was the final 3.x release.

## What

- `requirements/base.txt`: `posthog>=3.7,<4.0` → `posthog==7.21.1`

Exact pin (matching how most of base.txt pins) rather than a range, per [PostHog's guidance on keeping SDKs current](https://posthog.com/docs/health-checks/keeping-sdks-current): after the Shai-Hulud supply-chain attack they recommend adopting releases only after a minimum release age, and a range pin would grab whatever was published that day on every fresh install. 7.21.1 is the version their SDK Health page lists as latest.

## Compatibility

Our only SDK surface is `shared/analytics.py` (one `Posthog(key, host=...)` constructor, one `client.capture(distinct_id=, event=, properties=)` call). The v6 major flipped `capture()` to event-first, but all-keyword calls remain valid — `distinct_id` and `properties` are still accepted kwargs. No new background behavior: exception autocapture defaults off, geoip stays disabled by default, no flag polling without a personal API key.

## Testing

- Full suite: 360 tests, OK, on 7.21.1
- Smoke-tested the exact call shape from `shared/analytics.py` against the real 7.21.1 client (`send=False`) — the existing unit tests mock `Posthog`, so they alone wouldn't catch a signature break

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fHoX7KRmgoJ1K5dUeSmXF