### PR TITLE
Django 5.2.12 → 5.2.15 (clears all 8 Dependabot alerts) + pip Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,17 @@ updates:
           - "*"  # Group all Actions updates into a single larger pull request
     schedule:
       interval: weekly
+
+  # Keep pinned Python deps current instead of waiting for security alerts
+  # to accumulate (Django sat 3 patch releases behind in mid-2026).
+  - package-ecosystem: pip
+    directory: /requirements
+    groups:
+      pip:
+        patterns:
+          - "*"  # One grouped PR per week
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 3  # minimum release age before proposing an update
+

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,7 +3,7 @@ boto3==1.38.10
 botocore==1.38.10
 bs4==0.0.2
 certifi==2025.4.26
-Django==5.2.12
+Django==5.2.15
 django-admin-rangefilter==0.13.2
 django-ai-core==0.1.5
 django-compressor==4.5.1


### PR DESCRIPTION
## Why

All 8 open Dependabot alerts are the same package — Django 5.2.12 — fixed on the 5.2 LTS line:

| Fixed in | Severity | Alert |
|---|---|---|
| 5.2.13 | **High** | ASGI header spoofing via underscore/hyphen conflation |
| 5.2.13 | **High** | Missing/understated `Content-Length` bypasses `DATA_UPLOAD_MAX_MEMORY_SIZE` |
| 5.2.13 | Medium | DoS via crafted multipart uploads |
| 5.2.13 | Low ×2 | Privilege abuse in `ModelAdmin.list_editable` / `GenericInlineModelAdmin` |
| 5.2.14 | Medium | Improper handling of length parameter inconsistency |
| 5.2.14 | Low ×2 | Cache / persistent cookies containing sensitive information |

We take 5.2.15 (June 3), the newest patch on the LTS line, a month past release. No settings changes needed — none of the affected knobs are overridden in our settings.

## Maintenance fix

Dependabot's Django security PRs stopped arriving after March (#1670 was the last), so three patch releases piled up as alerts. `dependabot.yml` only had version updates for `github-actions` — this PR adds `pip`:

- Weekly, all updates grouped into one PR (mirrors the existing github-actions entry)
- `cooldown: default-days: 3` — release-age gate per [PostHog's supply-chain guidance](https://posthog.com/docs/health-checks/keeping-sdks-current) we adopted in #1724 (Dependabot's equivalent of minimum release age)

## Testing

- Full suite on a fresh test DB: **360 tests, OK**
- `pip check`: no broken requirements; `manage.py check`: no issues
- Note for reviewers: a `--keepdb` run showed mass errors from a stale reused test DB — a fresh-DB run (what CI does) is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fHoX7KRmgoJ1K5dUeSmXF