### PR TITLE
Fail loudly if SECRET_KEY is missing outside local/test

### DIFF
--- a/openstax/settings/base.py
+++ b/openstax/settings/base.py
@@ -27,7 +27,7 @@ if not SECRET_KEY:
         # Default to a key starting with django-insecure for local development.
         SECRET_KEY = 'django-insecure-wq21wtjo3@d_qfjvd-#td!%7gfy2updj2z+nev^k$iy%=m4_tr'
     else:
-        raise ImproperlyConfigured("The SECRET_KEY setting must not be empty.")
+        raise ImproperlyConfigured(f"SECRET_KEY is required when ENVIRONMENT is {ENVIRONMENT!r}. Set the SECRET_KEY environment variable.")
 
 # check if running local dev server - else default to DEBUG=False
 if len(sys.argv) > 1:

--- a/openstax/settings/base.py
+++ b/openstax/settings/base.py
@@ -6,6 +6,7 @@ import sentry_sdk
 from sentry_sdk.integrations.django import DjangoIntegration
 
 from dotenv import load_dotenv
+from django.core.exceptions import ImproperlyConfigured
 
 import logging.config
 from django.utils.log import DEFAULT_LOGGING
@@ -20,8 +21,13 @@ DEPLOYMENT_VERSION = os.getenv('DEPLOYMENT_VERSION')
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = os.path.join(os.path.dirname(__file__), '..', '..')
 
-# Default to a key starting with django-insecure for local development.
-SECRET_KEY = os.getenv('SECRET_KEY', 'django-insecure-wq21wtjo3@d_qfjvd-#td!%7gfy2updj2z+nev^k$iy%=m4_tr')
+SECRET_KEY = os.getenv('SECRET_KEY')
+if not SECRET_KEY:
+    if ENVIRONMENT in ('local', 'test'):
+        # Default to a key starting with django-insecure for local development.
+        SECRET_KEY = 'django-insecure-wq21wtjo3@d_qfjvd-#td!%7gfy2updj2z+nev^k$iy%=m4_tr'
+    else:
+        raise ImproperlyConfigured("The SECRET_KEY setting must not be empty.")
 
 # check if running local dev server - else default to DEBUG=False
 if len(sys.argv) > 1:


### PR DESCRIPTION
## Summary
- CMS's `SECRET_KEY` silently fell back to a hardcoded `django-insecure-...` string in *any* environment (including prod/staging) whenever the real secret failed to load, since the fallback lived directly in `os.getenv('SECRET_KEY', '<hardcoded>')`.
- That's a real risk: `SECRET_KEY` signs sessions, CSRF tokens, and cookies — a silent fallback to a value sitting in git history means a Secrets Manager hiccup or misconfiguration could let prod boot and serve traffic signed with a known key instead of failing the deploy.
- Mirrors the fail-fast guard already shipped in `sfapi`'s settings: keep the insecure default for local/test (dev experience unchanged, CI unaffected), raise `ImproperlyConfigured` for every other `ENVIRONMENT` value.
- Verified this doesn't break local dev, Docker, or CI: `ENVIRONMENT` defaults to `'local'` when unset (local/docker/test all leave it unset or override it to `'test'` post-import), so only real deployed environments (`ENVIRONMENT=prod/staging/dev`, set via bit-deployment's `django_init_env`) are affected.
- Companion infra fix already in `bit-deployment`'s shared `django` Ansible role provisions a throwaway `SECRET_KEY` at AMI bake time, so `collectstatic` still succeeds even though this raises for missing secrets in real environments.

## Test plan
- [ ] `coverage run --source '.' manage.py test --settings=openstax.settings.test` passes (ENVIRONMENT unset → falls back to insecure dev key, same as before)
- [ ] `docker compose up` still boots locally (docker.py overrides SECRET_KEY explicitly, unaffected)
- [ ] Confirm deploy pipeline (bit-deployment) still bakes/deploys cleanly with the paired django-role fix