### PR TITLE
Fix sync_thank_you_notes crashing on missing "Find Me A Home" school

### DIFF
--- a/salesforce/management/commands/sync_thank_you_notes.py
+++ b/salesforce/management/commands/sync_thank_you_notes.py
@@ -31,7 +31,9 @@ class Command(BaseCommand):
                     note.save()
 
 
-                account_id = school_list["Find Me A Home"]
+                account_id = school_list.get("Find Me A Home")
+                if account_id is None:
+                    capture_exception(Exception('School "Find Me A Home" not found — run update_schools'))
 
                 # If note has a school name, see if we can match it and use that account id when creating
                 if note.institution:
@@ -44,7 +46,7 @@ class Command(BaseCommand):
                             account_id = school_list[best_match]
                         else:
                             capture_exception(Exception(f"Could not find a match for {school_string}"))
-                            account_id = school_list["Find Me A Home"]
+                            account_id = school_list.get("Find Me A Home")
 
                 message = (note.thank_you_note or "").strip()
                 if not message and note.account_uuid:

--- a/salesforce/management/commands/update_schools.py
+++ b/salesforce/management/commands/update_schools.py
@@ -37,7 +37,7 @@ class Command(BaseCommand):
                                 "BillingLongitude, " \
                                 "Research_Agreement_Start_Date__c, " \
                                 "Research_Agreement_End_Date__c " \
-                                "FROM Account WHERE Industry = 'HE' OR Industry = 'K12'", lazy_operation=True)
+                                "FROM Account WHERE Industry = 'HE' OR Industry = 'K12' OR Name = 'Find Me A Home'", lazy_operation=True)
             sf_schools = []
             for list_results in fetch_results:
                 sf_schools.extend(list_results)

--- a/salesforce/tests.py
+++ b/salesforce/tests.py
@@ -295,6 +295,33 @@ class SyncThankYouNotesCommandTest(TestCase):
         self.assertNotIn('Accounts_UUID__c', payload)
         capture_exception.assert_not_called()
 
+    @patch('salesforce.management.commands.sync_thank_you_notes.capture_exception')
+    @patch('salesforce.management.commands.sync_thank_you_notes.Salesforce')
+    def test_missing_find_me_a_home_school_does_not_crash_the_batch(self, salesforce, capture_exception):
+        # simulates update_schools not having synced the "Find Me A Home" placeholder account
+        School.objects.filter(name='Find Me A Home').delete()
+        note = ThankYouNote.objects.create(
+            thank_you_note='OpenStax saved me a fortune, thank you!',
+            first_name='Sam',
+            last_name='Lee',
+            institution='Some Unmatched School',
+            contact_email_address='sam@example.com',
+            source='PDF download',
+        )
+
+        sf = salesforce.return_value.__enter__.return_value
+        sf.Thank_You_Note__c.create.return_value = {'id': 'a01nohome'}
+
+        call_command('sync_thank_you_notes')
+
+        sf.Thank_You_Note__c.create.assert_called_once()
+        payload = sf.Thank_You_Note__c.create.call_args.args[0]
+        self.assertIsNone(payload['Related_Account__c'])
+        capture_exception.assert_called()
+
+        note.refresh_from_db()
+        self.assertEqual(note.salesforce_id, 'a01nohome')
+
 
 class AdoptionOpportunityTest(TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary
- `update_schools` only syncs Salesforce Accounts where `Industry = 'HE'` or `'K12'`. The "Find Me A Home" catch-all Account (created 2021, `Industry = 'Other'`, confirmed via Salesforce field history it's never changed) was never pulled into the local `School` table — and any stale local copy gets deleted by `update_schools`'s cleanup step since it never matches the filter.
- `sync_thank_you_notes` did an unguarded `school_list["Find Me A Home"]` lookup on every note, so the missing key threw a `KeyError` and killed the *entire* sync run — no thank-you notes synced to Salesforce at all, not just ones needing the fallback account.

## Fix
- `update_schools.py`: added `OR Name = 'Find Me A Home'` to the SOQL query so the placeholder account always syncs regardless of Industry.
- `sync_thank_you_notes.py`: switched both `school_list["Find Me A Home"]` lookups to `.get()`, with a `capture_exception` if it's ever missing again, so a data gap degrades gracefully (note still syncs, just without a related account) instead of taking down the whole batch.
- Added a regression test reproducing the crash (missing school → no exception, note still syncs, exception captured for visibility).

## Test plan
- [x] `python manage.py test salesforce --settings=openstax.settings.test` — 39 passed
- [ ] Run `python manage.py update_schools` in production to backfill the placeholder account and unblock the note backlog