### PR TITLE
Promote a FlexPage to the home page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,6 +148,24 @@ publishes** (a human reviews and publishes in the Wagtail admin).
 Wagtail 7.4 note: prefer **deferred validation** for draft saves (required-field
 checks happen at publish time) and `ImageRenditionField` for headless images.
 
+## Home Page Workflow (Promote to Home)
+
+The `RootPage` (site root, serves `/`) never moves between environments — it was
+created after the wagtail-transfer preseed, so its ID differs per env and
+transfers would duplicate it (and drag the whole child tree along). Instead:
+
+1. Stage a homepage redesign as a **FlexPage** (previewable at `/<slug>`,
+   transferable between envs — first transfer creates the ID mapping).
+2. On the target env, use **"Promote to home page"** (button on FlexPages in
+   the page listing "..." menu and editor header) — it copies `layout`, `body`,
+   `school`, `promote_image`, `seo_title`, `search_description` onto that env's
+   RootPage as a **draft revision only**. A human reviews and publishes.
+
+Service: `pages/promote_home.py` (`promote_to_home(flex_page, user)`); view/hooks:
+`pages/views_promote.py`, `pages/wagtail_hooks.py`. Rollback = revision revert.
+Note: `RootPage.max_count = 1` is dead code (MTI — `RootPage.objects.count()`
+includes FlexPages), left in place deliberately.
+
 ## Additional Documentation
 
 - [CMS Editing Documentation](https://openstax.atlassian.net/wiki/spaces/BIT/pages/2193391617/CMS+Editing)

--- a/pages/promote_home.py
+++ b/pages/promote_home.py
@@ -1,0 +1,62 @@
+# pages/promote_home.py
+"""Copy a FlexPage's content onto the environment's RootPage as a draft revision.
+
+Mirrors the never-publish contract of authoring/drafts.py: this only ever
+creates a draft Revision on the site's RootPage. A human reviews and publishes
+in the Wagtail admin.
+"""
+from wagtail.models import Site
+
+from pages.models import RootPage
+
+PROMOTED_FIELDS = ('layout', 'body', 'school', 'promote_image', 'seo_title', 'search_description')
+
+
+class PromoteError(Exception):
+    """Base class for promote-to-home errors."""
+
+
+class HomePageNotFound(PromoteError):
+    """No default Site, no root page, or the root page isn't exactly a RootPage."""
+
+
+class HomePageLocked(PromoteError):
+    """The site root page is locked and can't be edited right now."""
+
+
+class PromotePermissionDenied(PromoteError):
+    """The user doesn't have edit permission on the site root page."""
+
+
+def promote_to_home(flex_page, user):
+    """Copy `flex_page`'s latest (possibly draft) content onto the default
+    Site's RootPage as a new draft revision. Returns the created Revision.
+
+    Never publishes; never touches the RootPage's title or slug.
+    """
+    site = Site.objects.filter(is_default_site=True).select_related('root_page').first()
+    if site is None or site.root_page is None:
+        raise HomePageNotFound('No default site (or site root page) is configured.')
+
+    root = site.root_page
+    # isinstance() would also match FlexPage (an MTI subclass of RootPage) --
+    # we need the site root to be exactly a RootPage, not a promoted FlexPage.
+    if root.specific_class is not RootPage:
+        raise HomePageNotFound('Default site root page is not a RootPage.')
+
+    root_specific = root.specific
+
+    if not root_specific.permissions_for_user(user).can_edit():
+        raise PromotePermissionDenied('User cannot edit the home page.')
+
+    if root_specific.locked:
+        raise HomePageLocked('Home page is locked and cannot be edited.')
+
+    # The editor's latest state, not necessarily live -- falls back to the
+    # live object itself when the FlexPage has no unpublished changes/revisions.
+    source = flex_page.get_latest_revision_as_object()
+
+    for field_name in PROMOTED_FIELDS:
+        setattr(root_specific, field_name, getattr(source, field_name))
+
+    return root_specific.save_revision(user=user, log_action=True, changed=True)

--- a/pages/templates/pages/promote_to_home_confirm.html
+++ b/pages/templates/pages/promote_to_home_confirm.html
@@ -1,0 +1,24 @@
+{% extends "wagtailadmin/generic/base.html" %}
+{% load i18n %}
+
+{% block main_content %}
+    <p>
+        {% blocktrans trimmed with title=flex_page.title %}
+            This will replace the home page's draft content with this page's content.
+            The live home page is not changed until someone publishes the draft.
+        {% endblocktrans %}
+    </p>
+    <p>
+        {% blocktrans trimmed with flex_title=flex_page.title home_title=home_page.title %}
+            Promote "{{ flex_title }}" to the home page ("{{ home_title }}")?
+        {% endblocktrans %}
+    </p>
+
+    <form action="{% url 'promote_to_home' flex_page.id %}" method="POST">
+        {% csrf_token %}
+        <div>
+            <button class="button" type="submit">{% trans "Yes, promote it" %}</button>
+            <a href="{% url 'wagtailadmin_pages:edit' flex_page.id %}" class="button button-secondary">{% trans "Cancel" %}</a>
+        </div>
+    </form>
+{% endblock %}

--- a/pages/templates/pages/promote_to_home_confirm.html
+++ b/pages/templates/pages/promote_to_home_confirm.html
@@ -9,9 +9,15 @@
         {% endblocktrans %}
     </p>
     <p>
-        {% blocktrans trimmed with flex_title=flex_page.title home_title=home_page.title %}
-            Promote "{{ flex_title }}" to the home page ("{{ home_title }}")?
-        {% endblocktrans %}
+        {% if home_page %}
+            {% blocktrans trimmed with flex_title=flex_page.title home_title=home_page.title %}
+                Promote "{{ flex_title }}" to the home page ("{{ home_title }}")?
+            {% endblocktrans %}
+        {% else %}
+            {% blocktrans trimmed with flex_title=flex_page.title %}
+                Promote "{{ flex_title }}" to the home page?
+            {% endblocktrans %}
+        {% endif %}
     </p>
 
     <form action="{% url 'promote_to_home' flex_page.id %}" method="POST">

--- a/pages/tests/test_promote_home.py
+++ b/pages/tests/test_promote_home.py
@@ -1,0 +1,143 @@
+# pages/tests/test_promote_home.py
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from wagtail.images.models import Image
+from wagtail.images.tests.utils import get_test_image_file
+from wagtail.models import Page, Site
+
+from pages import models as page_models
+from salesforce.models import School
+
+from pages.promote_home import (
+    promote_to_home,
+    HomePageNotFound,
+    HomePageLocked,
+    PromotePermissionDenied,
+)
+
+LANDING_LAYOUT = [{"type": "landing", "value": {"nav_links": [], "show_give_now_button": True}}]
+HERO_BODY = [{"type": "hero", "value": {"content": [], "image": None, "image_alt": "Alt", "config": []}}]
+DRAFT_HERO_BODY = [{"type": "hero", "value": {"content": [], "image": None, "image_alt": "Draft Alt", "config": []}}]
+
+
+class PromoteHomeTestBase(TestCase):
+    def setUp(self):
+        root = Page.objects.get(depth=1)
+        self.home = page_models.RootPage(title="Home", slug="site-root")
+        root.add_child(instance=self.home)
+
+        site = Site.objects.get(is_default_site=True)
+        site.root_page = self.home
+        site.save()
+        Site.clear_site_root_paths_cache()
+
+        self.school = School.objects.create(name="Test School")
+        self.image = Image.objects.create(title="Test Image", file=get_test_image_file())
+
+        self.flex = page_models.FlexPage(
+            title="Flex", slug="flex-page",
+            layout=LANDING_LAYOUT,
+            body=HERO_BODY,
+            school=self.school,
+            promote_image=self.image,
+            seo_title="Flex SEO Title",
+            search_description="Flex search description",
+        )
+        self.home.add_child(instance=self.flex)
+
+        self.staff = get_user_model().objects.create_user(
+            username="promoter", password="x", is_staff=True, is_superuser=True,
+        )
+
+
+class PromoteFieldCopyTests(PromoteHomeTestBase):
+    def test_copies_all_promoted_fields_and_leaves_no_revisions_case_uncrashed(self):
+        # self.flex has never had save_revision() called on it -- exercises the
+        # "no revisions on the FlexPage" path (get_latest_revision_as_object
+        # falls back to the live object).
+        self.assertIsNone(self.flex.get_latest_revision())
+
+        revision = promote_to_home(self.flex, self.staff)
+        promoted = revision.as_object()
+
+        # .raw_data is a lazy RawDataView; == across two views doesn't work
+        # elementwise, so compare as plain lists.
+        self.assertEqual(list(promoted.layout.raw_data), list(self.flex.layout.raw_data))
+        self.assertEqual(list(promoted.body.raw_data), list(self.flex.body.raw_data))
+        self.assertEqual(promoted.school_id, self.school.id)
+        self.assertEqual(promoted.promote_image_id, self.image.id)
+        self.assertEqual(promoted.seo_title, "Flex SEO Title")
+        self.assertEqual(promoted.search_description, "Flex search description")
+
+    def test_title_and_slug_untouched(self):
+        revision = promote_to_home(self.flex, self.staff)
+        promoted = revision.as_object()
+
+        self.assertEqual(promoted.title, "Home")
+        self.assertEqual(promoted.slug, "site-root")
+
+
+class PromoteDraftOnlyTests(PromoteHomeTestBase):
+    def test_live_root_unchanged_and_draft_recorded(self):
+        promote_to_home(self.flex, self.staff)
+
+        live_root = page_models.RootPage.objects.get(pk=self.home.pk)
+        self.assertEqual(list(live_root.layout.raw_data), [])
+        self.assertEqual(list(live_root.body.raw_data), [])
+        self.assertIsNone(live_root.school_id)
+        self.assertIsNone(live_root.promote_image_id)
+        self.assertEqual(live_root.seo_title, "")
+        self.assertTrue(live_root.has_unpublished_changes)
+        self.assertIsNotNone(live_root.get_latest_revision())
+
+
+class PromoteLatestRevisionSourceTests(PromoteHomeTestBase):
+    def test_uses_flex_page_draft_content_not_live(self):
+        # Give the FlexPage a draft that differs from what's on the live row.
+        self.flex.body = DRAFT_HERO_BODY
+        self.flex.save_revision(user=self.staff)  # draft only; not published
+
+        fresh_flex = page_models.FlexPage.objects.get(pk=self.flex.pk)
+        self.assertTrue(fresh_flex.has_unpublished_changes)
+
+        revision = promote_to_home(fresh_flex, self.staff)
+        promoted = revision.as_object()
+
+        self.assertEqual(list(promoted.body.raw_data), DRAFT_HERO_BODY)
+
+
+class PromoteLockTests(PromoteHomeTestBase):
+    def test_locked_home_page_refuses_and_creates_no_revision(self):
+        self.home.locked = True
+        self.home.locked_by = self.staff
+        self.home.save()
+
+        with self.assertRaises(HomePageLocked):
+            promote_to_home(self.flex, self.staff)
+
+        live_root = page_models.RootPage.objects.get(pk=self.home.pk)
+        self.assertIsNone(live_root.get_latest_revision())
+
+
+class PromotePermissionTests(PromoteHomeTestBase):
+    def test_user_without_edit_permission_is_denied(self):
+        plain_user = get_user_model().objects.create_user(username="viewer", password="x")
+
+        with self.assertRaises(PromotePermissionDenied):
+            promote_to_home(self.flex, plain_user)
+
+        live_root = page_models.RootPage.objects.get(pk=self.home.pk)
+        self.assertIsNone(live_root.get_latest_revision())
+
+
+class PromoteSiteRootTypeTests(PromoteHomeTestBase):
+    def test_flex_page_as_site_root_is_not_exactly_rootpage(self):
+        # A FlexPage is an MTI subclass of RootPage -- isinstance() would
+        # wrongly accept it, so the site root must be rejected exactly here.
+        site = Site.objects.get(is_default_site=True)
+        site.root_page = self.flex
+        site.save()
+        Site.clear_site_root_paths_cache()
+
+        with self.assertRaises(HomePageNotFound):
+            promote_to_home(self.flex, self.staff)

--- a/pages/tests/test_promote_home_admin.py
+++ b/pages/tests/test_promote_home_admin.py
@@ -1,0 +1,73 @@
+from django.test import TestCase
+from django.urls import reverse
+from wagtail.models import Page, Site
+from wagtail.test.utils import WagtailTestUtils
+
+from pages.models import FlexPage, GeneralPage, RootPage
+
+
+class PromoteToHomeAdminTests(TestCase, WagtailTestUtils):
+
+    def setUp(self):
+        wagtail_root = Page.objects.get(title="Root")
+
+        self.home = RootPage(title="Home", slug="openstax-homepage")
+        wagtail_root.add_child(instance=self.home)
+
+        site = Site.objects.get(is_default_site=True)
+        site.root_page = self.home
+        site.save()
+
+        self.flex_page = FlexPage(title="New Landing", slug="new-landing")
+        self.home.add_child(instance=self.flex_page)
+
+    def promote_url(self, page_id):
+        return reverse('promote_to_home', args=[page_id])
+
+    def test_get_confirm_renders_for_superuser(self):
+        self.login()
+        response = self.client.get(self.promote_url(self.flex_page.id))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "New Landing")
+
+    def test_post_creates_home_draft_revision_and_redirects(self):
+        self.login()
+        self.flex_page.seo_title = "Promoted SEO Title"
+        self.flex_page.save_revision().publish()
+
+        response = self.client.post(self.promote_url(self.flex_page.id))
+
+        self.home.refresh_from_db()
+        latest_revision = self.home.get_latest_revision()
+        self.assertIsNotNone(latest_revision)
+        self.assertEqual(latest_revision.as_object().seo_title, "Promoted SEO Title")
+        self.assertRedirects(response, reverse('wagtailadmin_pages:edit', args=[self.home.id]))
+
+    def test_non_flex_page_is_404(self):
+        self.login()
+        response = self.client.get(self.promote_url(self.home.id))
+        self.assertEqual(response.status_code, 404)
+
+        general_page = GeneralPage(title="General", slug="general")
+        Page.objects.get(title="Root").add_child(instance=general_page)
+        response = self.client.get(self.promote_url(general_page.id))
+        self.assertEqual(response.status_code, 404)
+
+    def test_anonymous_redirected_to_login(self):
+        response = self.client.get(self.promote_url(self.flex_page.id))
+        self.assertEqual(response.status_code, 302)
+        self.assertIn(reverse('wagtailadmin_login'), response.url)
+
+    def test_locked_home_page_blocks_promotion_with_error(self):
+        self.login()
+        self.home.locked = True
+        self.home.locked_by = None
+        self.home.save()
+
+        revision_count_before = self.home.revisions.count()
+        response = self.client.post(self.promote_url(self.flex_page.id), follow=True)
+
+        self.home.refresh_from_db()
+        self.assertEqual(self.home.revisions.count(), revision_count_before)
+        messages = list(response.context['messages'])
+        self.assertTrue(any('locked' in str(m).lower() for m in messages))

--- a/pages/views_promote.py
+++ b/pages/views_promote.py
@@ -1,0 +1,44 @@
+from django.contrib import messages
+from django.http import Http404
+from django.shortcuts import get_object_or_404, redirect, render
+from wagtail.models import Page, Site
+
+from pages.models import FlexPage
+from pages.promote_home import PromoteError, promote_to_home
+
+# register_admin_urls wraps every URL from this hook in require_admin_access
+# (wagtail/admin/urls/__init__.py), so anonymous/non-staff users are already
+# redirected to admin login before this view runs.
+
+
+def _current_home_page():
+    """Best-effort lookup of the home page, for display only (not the
+    permission/lock gate — promote_to_home is authoritative for that)."""
+    site = Site.objects.filter(is_default_site=True).first()
+    return site.root_page.specific if site else None
+
+
+def promote_to_home_view(request, page_id):
+    page = get_object_or_404(Page, pk=page_id)
+    if type(page.specific) is not FlexPage:
+        raise Http404("Not a FlexPage.")
+    flex_page = page.specific
+
+    if request.method == 'POST':
+        try:
+            revision = promote_to_home(flex_page, request.user)
+        except PromoteError as exc:
+            messages.error(request, str(exc))
+            return redirect('promote_to_home', page_id=page_id)
+
+        messages.success(
+            request,
+            "Home page draft updated from '{}'. Review and publish it.".format(flex_page.title),
+        )
+        return redirect('wagtailadmin_pages:edit', revision.object_id)
+
+    return render(request, 'pages/promote_to_home_confirm.html', {
+        'flex_page': flex_page,
+        'home_page': _current_home_page(),
+        'page_title': "Promote to home page",
+    })

--- a/pages/wagtail_hooks.py
+++ b/pages/wagtail_hooks.py
@@ -2,12 +2,15 @@ import os
 
 from django.contrib.staticfiles import finders
 from django.templatetags.static import static
+from django.urls import path, reverse
 from django.utils.html import format_html
 from wagtail import hooks
+from wagtail.admin import widgets as wagtailadmin_widgets
 from wagtail.snippets.models import register_snippet
 from wagtail.snippets.views.snippets import SnippetViewSet
 
-from pages.models import PersonTag
+from pages.models import FlexPage, PersonTag
+from pages.views_promote import promote_to_home_view
 
 
 def _versioned(path):
@@ -48,4 +51,39 @@ class PersonTagViewSet(SnippetViewSet):
 
 
 register_snippet(PersonTagViewSet)
+
+
+@hooks.register('register_admin_urls')
+def register_promote_to_home_url():
+    return [
+        path('promote-to-home/<int:page_id>/', promote_to_home_view, name='promote_to_home'),
+    ]
+
+
+def _is_flex_page(page):
+    # specific_class (content-type lookup) instead of .specific (extra query per row) —
+    # these hooks run once per listing row, so avoid fetching the full instance.
+    return page.specific_class is FlexPage
+
+
+@hooks.register('register_page_listing_more_buttons')
+def promote_to_home_listing_button(page, user, next_url=None):
+    if _is_flex_page(page):
+        yield wagtailadmin_widgets.Button(
+            'Promote to home page',
+            reverse('promote_to_home', args=[page.id]),
+            icon_name='upload',
+            priority=70,
+        )
+
+
+@hooks.register('register_page_header_buttons')
+def promote_to_home_header_button(page, user, view_name, next_url=None):
+    if _is_flex_page(page):
+        yield wagtailadmin_widgets.Button(
+            'Promote to home page',
+            reverse('promote_to_home', args=[page.id]),
+            icon_name='upload',
+            priority=80,
+        )
 


### PR DESCRIPTION
## Summary

The home page (`RootPage`) can't be moved between environments: it postdates the wagtail-transfer preseed (different ID per env → transfers duplicate instead of update), and transferring it drags the entire child tree along. This PR sidesteps both by never transferring the RootPage at all:

- Stage a homepage redesign as a **FlexPage** — previewable at `/<slug>` and transferable between envs today (first transfer creates the ID mapping, re-syncs update in place).
- On the target env, **"Promote to home page"** (new button on FlexPages in the page listing "..." menu and editor header) copies `layout`, `body`, `school`, `promote_image`, `seo_title`, `search_description` onto that env's RootPage as a **draft revision only**. A human reviews and publishes in the admin; rollback is the built-in revision-history revert.

## Implementation

- `pages/promote_home.py` — service: default-site root resolution with an exact-class `RootPage` check (`FlexPage` is an MTI subclass, so `isinstance` would wrongly match), `permissions_for_user().can_edit()` gate, page-lock refusal, source content from the FlexPage's latest revision, `save_revision()` only — never `save()`/publish, `title`/`slug` untouched.
- `pages/views_promote.py` + `pages/templates/pages/promote_to_home_confirm.html` — GET confirmation → POST promote → redirect to the RootPage editor with a message. Admin URLs are auto-wrapped in `require_admin_access`.
- `pages/wagtail_hooks.py` — `register_admin_urls`, `register_page_listing_more_buttons`, `register_page_header_buttons`; listing hook uses `specific_class` (no per-row fetch).

Rejected alternatives (multi-RootPage + `Site.root_page` switch; non-recursive transfer) and rationale are in the local design spec; short version: the API queryset is hard-scoped to `descendant_of(site.root_page)` (`openstax/api.py:155`), so staged sibling roots are invisible to the SPA, and a root switch would need to move all ~26 children transactionally with no review gate.

## Testing

- 12 new tests (`pages/tests/test_promote_home.py`, `test_promote_home_admin.py`): field-copy fidelity, draft-only guarantees, latest-revision source, lock/permission refusal, non-FlexPage 404s, login enforcement.
- Full `pages` + `authoring` suites: **259/259 pass** on a fresh test DB.
- Smoke-tested against the local dev DB via Django test client: buttons render in listing + editor header, RootPage correctly excluded, confirm page renders.