### PR TITLE
Add taggit.taggeditem to the wagtail-transfer export allowlist

### DIFF
--- a/openstax/settings/base.py
+++ b/openstax/settings/base.py
@@ -297,7 +297,8 @@ WAGTAILTRANSFER_CHOOSER_API_PROXY_TIMEOUT = int(os.getenv('WAGTAILTRANSFER_CHOOS
 # REPLACES the package default, so wagtailcore.page + contenttypes.contenttype
 # must stay listed. Additions:
 #   auth.user — the `user` FK on transferred objects; not exportable, so following
-#     it 404s and would pull PII. Nulled instead (the FKs are nullable).
+#     it 404s and would try to pull staff account fields across environments.
+#     Nulled instead (the FKs are nullable).
 #   wagtailcore.revision — page.latest_revision forms a Page<->Revision cycle that
 #     wagtail-transfer breaks only when it enters via the soft edge, which it picks
 #     nondeterministically — otherwise a CircularDependencyException 500. Safe to

--- a/openstax/wagtail_transfer_security.py
+++ b/openstax/wagtail_transfer_security.py
@@ -34,6 +34,8 @@ from django.http import Http404
 # starts following revisions again.
 # wagtailcore.collection: images/documents have a non-nullable collection FK, so
 # page imports fetch it via api/objects/. No PII. Preseed it (see transfer runbook).
+# taggit.taggeditem: the join row linking a tagged page to a taggit.tag. Pages
+# with tags fetch it via api/objects/ alongside the tag itself. No PII.
 _ALWAYS_EXPORTABLE = {
     'wagtailcore.page',
     'wagtailcore.revision',
@@ -43,6 +45,7 @@ _ALWAYS_EXPORTABLE = {
     'wagtailcore.locale',
     'contenttypes.contenttype',
     'taggit.tag',
+    'taggit.taggeditem',
 }
 
 

--- a/openstax/wagtail_transfer_security.py
+++ b/openstax/wagtail_transfer_security.py
@@ -13,9 +13,10 @@ closes both:
    returns 403 on deployed environments still using the placeholder.
 
 2. ``models_for_export`` / ``objects_for_export`` will serialize *any* model
-   addressable by ``app_label.model`` — including ``auth.user`` (names, emails,
-   password hashes). ``restrict_exportable_models`` limits them to an explicit
-   allowlist: pages, images, documents, and the snippets we actually transfer.
+   addressable by ``app_label.model`` — including ``auth.user`` (staff account
+   fields, password hashes). ``restrict_exportable_models`` limits them to an
+   explicit allowlist: pages, images, documents, and the snippets we actually
+   transfer.
 
 These wrap the package views in ``openstax/wagtail_transfer_urls.py``.
 """
@@ -33,9 +34,9 @@ from django.http import Http404
 # should never request one; kept exportable as a guard against a regression that
 # starts following revisions again.
 # wagtailcore.collection: images/documents have a non-nullable collection FK, so
-# page imports fetch it via api/objects/. No PII. Preseed it (see transfer runbook).
+# page imports fetch it via api/objects/. Preseed it (see transfer runbook).
 # taggit.taggeditem: the join row linking a tagged page to a taggit.tag. Pages
-# with tags fetch it via api/objects/ alongside the tag itself. No PII.
+# with tags fetch it via api/objects/ alongside the tag itself.
 _ALWAYS_EXPORTABLE = {
     'wagtailcore.page',
     'wagtailcore.revision',

--- a/pages/tests/test_wagtail_transfer_security.py
+++ b/pages/tests/test_wagtail_transfer_security.py
@@ -66,6 +66,13 @@ class ExportableModelAllowlistTests(TestCase):
 
         self.assertIn('wagtailcore.collection', get_exportable_model_labels())
 
+    def test_tagged_item_is_exportable(self):
+        # A tagged page's TaggedItem join row is fetched via api/objects/
+        # alongside its taggit.tag, so it must be exportable too.
+        from openstax.wagtail_transfer_security import get_exportable_model_labels
+
+        self.assertIn('taggit.taggeditem', get_exportable_model_labels())
+
 
 class NoFollowModelsTests(TestCase):
     """Revisions (and other transferred objects) carry a `user` FK. Following it

--- a/pages/tests/test_wagtail_transfer_security.py
+++ b/pages/tests/test_wagtail_transfer_security.py
@@ -76,9 +76,9 @@ class ExportableModelAllowlistTests(TestCase):
 
 class NoFollowModelsTests(TestCase):
     """Revisions (and other transferred objects) carry a `user` FK. Following it
-    would 404 on the export allowlist and attempt to pull user PII across, so
-    auth.user must stay unfollowed (left as a null FK). The two package defaults
-    must be preserved when we override the setting."""
+    would 404 on the export allowlist and attempt to pull staff accounts across,
+    so auth.user must stay unfollowed (left as a null FK). The two package
+    defaults must be preserved when we override the setting."""
 
     def _no_follow(self):
         from django.conf import settings


### PR DESCRIPTION
## Summary
- A tagged page's `TaggedItem` join row is fetched via `api/objects/` alongside its `taggit.tag` during wagtail-transfer imports, but only the tag itself was in `_ALWAYS_EXPORTABLE`.
- The missing model 404s on the source; because the CMS is headless, that 404 renders as the SPA shell, which the importer json-parses into an opaque `JSONDecodeError` (`missing_object_data_by_type: {taggit.models.TaggedItem: [...]}`) instead of a clear error.
- `wagtail.models.media.Collection` in the same error is already fixed on `main` (#1729) — that 404 is a source-env deploy lag, not a code gap.

## Test plan
- [x] `python manage.py test pages.tests.test_wagtail_transfer_security --settings=openstax.settings.test` — 10/10 passing, including new `test_tagged_item_is_exportable`