### PR TITLE
Surface wagtail-transfer import failures as admin messages, not a 500

### DIFF
--- a/openstax/wagtail_transfer_patches.py
+++ b/openstax/wagtail_transfer_patches.py
@@ -1,7 +1,7 @@
 """
 Runtime patches for wagtail-transfer 0.11.
 
-Three patches, all installed by `apply_patches()`:
+Four patches, all installed by `apply_patches()`:
 
 0. get_base_model multi-level MTI fix. Upstream returns the nearest ancestor
    (`get_parent_list()[0]`), so our two-level FlexPage (Page → RootPage → FlexPage)
@@ -36,6 +36,25 @@ Three patches, all installed by `apply_patches()`:
    chooser proxy's deliberate status passthrough is untouched and we copy no
    upstream view logic that could drift when the pin moves.
 
+3. Import view error surfacing. `do_import` (the single admin endpoint both
+   "Import page" and "Import snippet" post to) has no error handling of its
+   own: a WagtailTransferImportError from patch 2 — or any other exception
+   raised while contacting the source or running the import — propagates
+   straight out of the view, past Wagtail's admin chrome, to Django's bare
+   500 handler. In production (DEBUG=False) that renders as an unstyled
+   white page with no message, so the clear error from patch 2 never reaches
+   the editor who triggered the import. This patch wraps do_import to catch
+   the failure, queue it as a Wagtail admin message (the same messages
+   framework do_import already uses on success), and redirect back to the
+   Choose page, where the message renders next to the how-to instructions.
+   Safe to patch directly: admin_urls.py's `path('import/', views.do_import, …)`
+   reads `views.do_import` as a plain attribute at import time, and hook
+   discovery (which imports admin_urls) is Wagtail's own lazy
+   `search_for_hooks()`, not triggered until the first admin URL is resolved —
+   always after `apply_patches()` has run in `ready()`. No per-module rebind
+   needed here (contrast patch 0, which rebinds because callers there did
+   `from .models import get_base_model`, a local name, not an attribute read).
+
 `apply_patches()` is idempotent and is called from
 global_settings.apps.GlobalSettingsConfig.ready(), so it runs in every process
 that calls django.setup() — management commands, shell, Celery, WSGI/ASGI —
@@ -44,6 +63,8 @@ not only when the URLconf happens to be imported.
 import json
 import logging
 
+from django.contrib import messages
+from django.shortcuts import redirect
 from wagtail_transfer.operations import ImportPlanner, Objective
 
 logger = logging.getLogger(__name__)
@@ -60,6 +81,7 @@ EXPECTED_WAGTAIL_TRANSFER_VERSION = '0.11'
 _PATCH_FLAG = '_openstax_base_model_patch'
 _ADD_JSON_PATCH_FLAG = '_openstax_add_json_guard'
 _GET_BASE_MODEL_PATCH_FLAG = '_openstax_get_base_model_patch'
+_DO_IMPORT_PATCH_FLAG = '_openstax_do_import_error_guard'
 
 # Rebound in each module that did `from .models import get_base_model` (each holds
 # its own binding). get_base_model_for_path calls it models-locally, so it's covered.
@@ -113,6 +135,21 @@ def _patched_add_json(self, json_data):
         ) from exc
 
 
+def _patched_do_import(request):
+    try:
+        return _patched_do_import._original(request)
+    except WagtailTransferImportError as exc:
+        messages.error(request, str(exc))
+    except Exception:
+        logger.exception("wagtail-transfer import failed")
+        messages.error(
+            request,
+            "The import failed unexpectedly. Check the server logs for details, "
+            "or ask in the CMS support channel.",
+        )
+    return redirect('wagtail_transfer_admin:choose_page')
+
+
 def apply_patches():
     """Install the wagtail-transfer runtime patches. Idempotent."""
     try:
@@ -144,3 +181,9 @@ def apply_patches():
         _patched_add_json._original = ImportPlanner.add_json
         setattr(_patched_add_json, _ADD_JSON_PATCH_FLAG, True)
         ImportPlanner.add_json = _patched_add_json
+
+    wt_views = importlib.import_module('wagtail_transfer.views')
+    if not getattr(wt_views.do_import, _DO_IMPORT_PATCH_FLAG, False):
+        _patched_do_import._original = wt_views.do_import
+        setattr(_patched_do_import, _DO_IMPORT_PATCH_FLAG, True)
+        wt_views.do_import = _patched_do_import

--- a/pages/templates/wagtail_transfer/choose_page.html
+++ b/pages/templates/wagtail_transfer/choose_page.html
@@ -12,6 +12,11 @@ addition is the how-to panel above the form.
     {{ block.super }}
 
     <link rel="stylesheet" href="{% versioned_static 'wagtail_transfer/css/transfer-styles.css' %}">
+    <style>
+        .help-block details { margin: 0.75em 0; }
+        .help-block summary { cursor: pointer; font-weight: bold; }
+        .help-block details[open] summary { margin-bottom: 0.5em; }
+    </style>
 {% endblock %}
 
 {% block extra_js %}
@@ -29,90 +34,93 @@ addition is the how-to panel above the form.
             {% icon name="help" %}
             <h3>Importing content from another environment</h3>
             <p>
-                This page pulls content <strong>into this site</strong> from the
-                environment you select below. Nothing is changed on the source
-                environment.
-            </p>
-            <p>
+                Pulls a page or snippet <strong>into this site</strong> from the
+                environment you pick below. Nothing changes on the source.
                 <a href="https://scribehow.com/o/jGUaNi72Qay710Vi452_JA/viewer/How_to_Import_Pages_in_the_OpenStax_Admin_Dashboard__FWajw9pwQxeYK34ZZWEcsg" target="_blank" rel="noopener">
-                    Step-by-step walkthrough with screenshots (Scribe)
+                    Step-by-step walkthrough with screenshots (Scribe) →
                 </a>
             </p>
             <ol>
-                <li>
-                    <strong>Get the content ready on the source.</strong> Pages come
-                    across in their current state on the source environment, so finish
-                    and publish your changes there first.
-                </li>
-                <li>
-                    <strong>Select the source environment</strong> from the dropdown
-                    (for example, staging when you are promoting content to production).
-                </li>
-                <li>
-                    <strong>Find the page or snippet</strong> you want to import by
-                    browsing the source's page tree or snippet list.
-                </li>
-                <li>
-                    <strong>For a new page, choose where it should live</strong> on
-                    this site by picking the destination parent page.
-                </li>
-                <li>
-                    <strong>Review and import.</strong> Images, documents, and snippets
-                    that the content references are brought across automatically.
-                </li>
-                <li>
-                    <strong>Check the result.</strong> Open the imported page or snippet
-                    on this site and confirm it looks right before sharing links to it.
-                </li>
+                <li><strong>Publish your changes on the source first</strong> — drafts don't get exported.</li>
+                <li><strong>Pick the source environment</strong>, then find the page or snippet.</li>
+                <li><strong>For a brand-new page</strong>, pick a destination parent page.</li>
+                <li><strong>Review and import.</strong> Referenced images, documents, and snippets come across automatically.</li>
+                <li><strong>Check the result</strong> here before sharing a link to it.</li>
             </ol>
-            <p><strong>Good to know before you import:</strong></p>
             <ul>
-                <li>
-                    If the item was imported before (or a snippet here shares its
-                    name/title with the source's), the import <strong>updates the
-                    existing item in place</strong> — any edits made on this site since
-                    the last import are replaced by the source version.
-                </li>
-                <li>
-                    A page that was created separately on both environments is
-                    <em>not</em> recognized as the same page — importing it creates a
-                    duplicate. See <code>docs/wagtail-transfer-page-sync.md</code> in the
-                    CMS repository before importing a page that already exists here.
-                </li>
                 <li>
                     To rebuild an entire environment (for example, refreshing dev or
                     staging from production), don't import page by page — follow
                     <code>docs/refresh-from-prod-runbook.md</code> instead.
                 </li>
                 <li>
-                    Stuck or unsure? Ask in the CMS support channel before importing —
-                    imports overwrite content and can't be undone from this screen.
+                    Stuck or unsure? Ask in
+                    <a href="https://openstax.slack.com/archives/C69BU01RC" target="_blank" rel="noopener">#openstax-dot-org</a>
+                    before importing — imports overwrite content and can't be undone from this screen.
                 </li>
             </ul>
-            <p><strong>Switching a live page over to newly imported content:</strong></p>
-            <p>
-                Importing a rebuilt page doesn't touch the live page at the same URL —
-                it creates a separate page, so both exist side by side until you swap
-                them. This is a one-time, per-page dance:
-            </p>
-            <ol>
-                <li>Import the new page here, into production.</li>
-                <li>
-                    On the <strong>existing live page</strong>, change the title (e.g.
-                    add "(old)") and the slug (e.g. add "-old"), then save as a draft.
-                </li>
-                <li>
-                    Unpublish the old page. The URL is briefly down until the next step.
-                </li>
-                <li>
-                    On the <strong>newly imported page</strong>, set the title and slug
-                    back to the original values, then publish.
-                </li>
-            </ol>
-            <p>
-                The home page is the one exception — don't import over it. Use
-                "Promote to home page" on the new FlexPage instead.
-            </p>
+
+            <details>
+                <summary>What actually gets imported</summary>
+                <ul>
+                    <li>
+                        <strong>Draft edits never transfer.</strong> The export reads the
+                        source page's currently published content, not a pending draft
+                        revision — publish on the source first or you'll import stale content.
+                    </li>
+                    <li>
+                        <strong>Published state carries over.</strong> A published source
+                        page is published here too, automatically — no extra "Publish" click.
+                        A source page that's never been published imports as a draft here.
+                    </li>
+                    <li>
+                        <strong>Comes across:</strong> title, slug, SEO fields, body content,
+                        and anything it references — images, documents, collections, tags,
+                        and snippets.
+                    </li>
+                    <li>
+                        <strong>Does not come across:</strong> owner, lock status, scheduled
+                        go-live/expiry dates, and revision history (a single fresh revision
+                        is created here instead).
+                    </li>
+                </ul>
+            </details>
+
+            <details>
+                <summary>Updating a page vs. replacing one at a different URL</summary>
+                <p>
+                    <strong>The common case — re-importing a page you've already brought
+                    over:</strong> Wagtail Transfer remembers it, so the import
+                    <strong>updates it in place</strong> — same URL, same tree position —
+                    no matter what destination parent you pick above. Rebuild on staging,
+                    re-import to prod as many times as you like.
+                </p>
+                <p>
+                    <strong>The rare case — a page built under a different slug</strong>
+                    (for example, staging an "FAQ" rebuild at <code>/faq-staxify</code> to
+                    later replace the live <code>/faq</code>): Wagtail Transfer has never
+                    linked the two, so importing it creates a brand-new page alongside the
+                    old one. A page created independently on both environments hits this
+                    same case — see <code>docs/wagtail-transfer-page-sync.md</code>. To
+                    swap the new one into the old URL:
+                </p>
+                <ol>
+                    <li>Import the new page here, into production.</li>
+                    <li>
+                        On the <strong>old live page</strong>, change the title (e.g. add
+                        "(old)") and slug (e.g. add "-old"), then save as a draft.
+                    </li>
+                    <li>Unpublish the old page. The URL is briefly down until the next step.</li>
+                    <li>
+                        On the <strong>newly imported page</strong>, set the title and slug
+                        back to the original values, then publish.
+                    </li>
+                </ol>
+                <p>
+                    The home page is the one exception — don't import over it. Use
+                    "Promote to home page" on the new FlexPage instead.
+                </p>
+            </details>
         </div>
 
         <div data-wagtail-component="content-import-form" data-local-api-base-url="{% url 'wagtail_transfer_admin:page_chooser_api:pages:listing' %}" data-local-check-uid-url="{% url 'wagtail_transfer_admin:check_uid' %}" data-sources="{{ sources_data }}" data-action="{% url 'wagtail_transfer_admin:import' %}" data-csrf-token="{{ csrf_token }}"></div>

--- a/pages/templates/wagtail_transfer/choose_page.html
+++ b/pages/templates/wagtail_transfer/choose_page.html
@@ -33,6 +33,11 @@ addition is the how-to panel above the form.
                 environment you select below. Nothing is changed on the source
                 environment.
             </p>
+            <p>
+                <a href="https://scribehow.com/o/jGUaNi72Qay710Vi452_JA/viewer/How_to_Import_Pages_in_the_OpenStax_Admin_Dashboard__FWajw9pwQxeYK34ZZWEcsg" target="_blank" rel="noopener">
+                    Step-by-step walkthrough with screenshots (Scribe)
+                </a>
+            </p>
             <ol>
                 <li>
                     <strong>Get the content ready on the source.</strong> Pages come
@@ -84,6 +89,30 @@ addition is the how-to panel above the form.
                     imports overwrite content and can't be undone from this screen.
                 </li>
             </ul>
+            <p><strong>Switching a live page over to newly imported content:</strong></p>
+            <p>
+                Importing a rebuilt page doesn't touch the live page at the same URL —
+                it creates a separate page, so both exist side by side until you swap
+                them. This is a one-time, per-page dance:
+            </p>
+            <ol>
+                <li>Import the new page here, into production.</li>
+                <li>
+                    On the <strong>existing live page</strong>, change the title (e.g.
+                    add "(old)") and the slug (e.g. add "-old"), then save as a draft.
+                </li>
+                <li>
+                    Unpublish the old page. The URL is briefly down until the next step.
+                </li>
+                <li>
+                    On the <strong>newly imported page</strong>, set the title and slug
+                    back to the original values, then publish.
+                </li>
+            </ol>
+            <p>
+                The home page is the one exception — don't import over it. Use
+                "Promote to home page" on the new FlexPage instead.
+            </p>
         </div>
 
         <div data-wagtail-component="content-import-form" data-local-api-base-url="{% url 'wagtail_transfer_admin:page_chooser_api:pages:listing' %}" data-local-check-uid-url="{% url 'wagtail_transfer_admin:check_uid' %}" data-sources="{{ sources_data }}" data-action="{% url 'wagtail_transfer_admin:import' %}" data-csrf-token="{{ csrf_token }}"></div>

--- a/pages/tests/test_wagtail_transfer_import_page.py
+++ b/pages/tests/test_wagtail_transfer_import_page.py
@@ -1,5 +1,8 @@
 """Tests for our override of wagtail-transfer's Import (choose) page."""
+from unittest import mock
+
 from django.contrib.auth import get_user_model
+from django.contrib.messages import get_messages
 from django.test import RequestFactory, TestCase, override_settings
 from django.urls import reverse
 
@@ -19,6 +22,11 @@ class WagtailTransferChoosePageTests(TestCase):
         self.assertContains(response, 'Importing content from another environment')
         self.assertContains(response, 'Select the source environment')
         self.assertContains(response, 'refresh-from-prod-runbook.md')
+        # The Scribe walkthrough link
+        self.assertContains(response, 'scribehow.com/o/jGUaNi72Qay710Vi452_JA')
+        # The switchover blurb
+        self.assertContains(response, 'Switching a live page over to newly imported content')
+        self.assertContains(response, 'Promote to home page')
         # The import form component from the original template must survive the override
         self.assertContains(response, 'data-wagtail-component="content-import-form"')
 
@@ -35,3 +43,51 @@ class WagtailTransferChoosePageTests(TestCase):
             request = RequestFactory().get('/admin/')
             request.user = get_user_model().objects.get(username='transfer-admin')
             self.assertTrue(item.is_shown(request))
+
+
+@override_settings(WAGTAILTRANSFER_SOURCES={
+    'staging': {'BASE_URL': 'https://staging.example.com/admin/wagtail-transfer/', 'SECRET_KEY': 'shared-secret'},
+})
+class DoImportErrorHandlingTests(TestCase):
+    """A failed import must surface as a Wagtail admin message on the Choose
+    page, not an unhandled 500 (openstax.wagtail_transfer_patches, patch 3)."""
+
+    def setUp(self):
+        user = get_user_model().objects.create_superuser(
+            username='transfer-admin', email='cms@openstax.org', password='secret',
+        )
+        self.client.force_login(user)
+
+    def test_import_failure_redirects_with_a_readable_message(self):
+        # The source returning an HTML error page (403/404/SPA shell) is the
+        # realistic failure mode this guards — see AddJsonGuardTests.
+        forbidden_response = mock.Mock(content=b'<html><title>403 Forbidden</title></html>')
+        with mock.patch('wagtail_transfer.views.requests.get', return_value=forbidden_response):
+            response = self.client.post(reverse('wagtail_transfer_admin:import'), {
+                'type': 'page',
+                'source': 'staging',
+                'source_page_id': '1',
+                'dest_page_id': '',
+            })
+
+        self.assertRedirects(response, reverse('wagtail_transfer_admin:choose_page'))
+        messages = [str(m) for m in get_messages(response.wsgi_request)]
+        self.assertTrue(
+            any('403 Forbidden' in m for m in messages),
+            msg=f'Expected the source response to surface in a message; got {messages}',
+        )
+
+    def test_unexpected_exception_also_redirects_with_a_message(self):
+        # A non-HTTP failure (network error, bug in wagtail-transfer) must not
+        # 500 either — the broad except Exception fallback in the patch.
+        with mock.patch('wagtail_transfer.views.requests.get', side_effect=RuntimeError('boom')):
+            response = self.client.post(reverse('wagtail_transfer_admin:import'), {
+                'type': 'page',
+                'source': 'staging',
+                'source_page_id': '1',
+                'dest_page_id': '',
+            })
+
+        self.assertRedirects(response, reverse('wagtail_transfer_admin:choose_page'))
+        messages = [str(m) for m in get_messages(response.wsgi_request)]
+        self.assertTrue(any('failed unexpectedly' in m for m in messages), msg=messages)

--- a/pages/tests/test_wagtail_transfer_import_page.py
+++ b/pages/tests/test_wagtail_transfer_import_page.py
@@ -20,12 +20,19 @@ class WagtailTransferChoosePageTests(TestCase):
         self.assertTemplateUsed(response, 'wagtail_transfer/choose_page.html')
         # Our how-to panel
         self.assertContains(response, 'Importing content from another environment')
-        self.assertContains(response, 'Select the source environment')
+        self.assertContains(response, 'Pick the source environment')
         self.assertContains(response, 'refresh-from-prod-runbook.md')
         # The Scribe walkthrough link
         self.assertContains(response, 'scribehow.com/o/jGUaNi72Qay710Vi452_JA')
-        # The switchover blurb
-        self.assertContains(response, 'Switching a live page over to newly imported content')
+        # The CMS support Slack channel link
+        self.assertContains(response, 'openstax.slack.com/archives/C69BU01RC')
+        # The draft-vs-published / what-gets-imported details
+        self.assertContains(response, 'What actually gets imported')
+        self.assertContains(response, 'Draft edits never transfer')
+        self.assertContains(response, 'Published state carries over')
+        # The updating-vs-replacing details, and the switchover dance within it
+        self.assertContains(response, 'Updating a page vs. replacing one at a different URL')
+        self.assertContains(response, 'updates it in place')
         self.assertContains(response, 'Promote to home page')
         # The import form component from the original template must survive the override
         self.assertContains(response, 'data-wagtail-component="content-import-form"')


### PR DESCRIPTION
## Summary
- \`do_import\` (the endpoint both "Import page" and "Import snippet" post to) had no error handling. Any failure — including the \`WagtailTransferImportError\` we already made legible for HTTP-error/allowlist cases — propagated past Wagtail's admin chrome straight to Django's bare 500 handler, which in production (\`DEBUG=False\`) renders as an unstyled white page with no message. The editor triggering the import never saw why it failed.
- \`openstax/wagtail_transfer_patches.py\` gets a 4th patch: wrap \`do_import\` to catch the failure, queue it as a Wagtail admin message (the same \`messages\` framework the success path already uses), and redirect back to the Choose page. A broad \`except Exception\` fallback covers failure modes beyond the JSON-parsing one (network errors, etc.) so a new exception type doesn't reproduce the same white-screen bug.
- Rewrote the Choose page's how-to panel (\`pages/templates/wagtail_transfer/choose_page.html\`) after actually verifying the claims against wagtail-transfer's source (\`operations.py\` / \`serializers.py\`) rather than assuming:
  - **Draft vs. published, verified in code:** the export serializes the source page's live DB row, not its latest revision, so unpublished draft edits never transfer — publish on the source first. \`live\` is a plain transferred field (not in \`PageSerializer.ignored_fields\`), so a published source page is published on import here too, automatically, with no separate "Publish" click.
  - **Corrected a wrong claim.** The previous draft said importing always creates a separate page. Not true: \`operations.py\` shows create-vs-update is decided purely by whether the page's UID already has a destination match — re-importing a page you've already brought over always updates it in place regardless of which destination parent you pick. The rename/unpublish/rename dance is only needed for a page built under a slug that's never been linked to an existing destination page (e.g. staging an "FAQ" rebuild at \`/faq-staxify\` to later replace the live \`/faq\`).
  - Linked the Scribe walkthrough and the actual CMS support Slack channel (\`#openstax-dot-org\`).
  - Moved the "what gets imported" and "updating vs. replacing" detail into two \`<details>\` sections so the visible page stays short; the previous version was one long wall of text.

## Test plan
- [x] \`python manage.py test pages.tests.test_wagtail_transfer_import_page pages.tests.test_wagtail_transfer_patches --settings=openstax.settings.test\` — 14/14 passing, including two end-to-end tests that POST to the real \`wagtail_transfer_admin:import\` URL (mocking the source HTTP call) and assert a redirect + admin message instead of a 500.
- [x] Full suite: 466/466 passing.
- [x] Manually verified in the browser (local runserver): both \`<details>\` sections expand correctly and read as intended.