### PR TITLE
Restore the Webinar admin date/time picker

### DIFF
--- a/openstax/settings/local.py.example
+++ b/openstax/settings/local.py.example
@@ -1,4 +1,4 @@
-from .base import INSTALLED_APPS, MIDDLEWARE
+from .base import *
 INSTALLED_APPS += (
     'debug_toolbar',
     'django_extensions',

--- a/webinars/wagtail_hooks.py
+++ b/webinars/wagtail_hooks.py
@@ -1,3 +1,4 @@
+from wagtail.admin.forms.models import formfield_for_dbfield
 from wagtail.admin.viewsets.model import ModelViewSet
 
 from .models import Webinar
@@ -14,3 +15,13 @@ class WebinarViewSet(ModelViewSet):
     list_filter = ("start", "display_on_tutor_page")
     search_fields = ("title",)
     exclude_form_fields = []
+
+    def formfield_for_dbfield(self, db_field, **kwargs):
+        # Without panels/edit_handler, bare ModelViewSet.get_edit_handler()
+        # returns None and get_form_class() falls back to a plain
+        # modelform_factory whose default formfield_for_dbfield skips
+        # Wagtail's admin widget registry -- so start/end silently lost the
+        # AdminDateTimeInput calendar picker (and its initDateTimeChooser JS)
+        # in favor of a bare text input. Delegate to Wagtail's own
+        # registry-aware version instead of Django's default.
+        return formfield_for_dbfield(db_field, **kwargs)


### PR DESCRIPTION
## Summary
- `WebinarViewSet` extends bare `ModelViewSet` without `panels`/`edit_handler`, so `get_edit_handler()` returns `None` and form generation falls back to a plain `modelform_factory` whose default `formfield_for_dbfield` skips Wagtail's admin widget registry — `start`/`end` silently lost `AdminDateTimeInput` (and its calendar-picker JS) for a bare text input. Every other model here goes through `SnippetViewSet`, which auto-generates panels and doesn't hit this. Fix: delegate to Wagtail's own registry-aware `formfield_for_dbfield`.
- Bonus fix: `local.py.example` only imported `INSTALLED_APPS`/`MIDDLEWARE` from `base` instead of `from .base import *` (unlike `docker.py`/`test.py`) — left `STATIC_URL`, `DATABASES`, etc. undefined and crashed `runserver` via django-compressor's `COMPRESS_URL` lookup.

## Test plan
- [x] `python manage.py test webinars --settings=openstax.settings.test` (4/4 passing)
- [x] Verified locally via `Client().get('/admin/webinars/new/')` — rendered `start`/`end` inputs now include `autocomplete="off"` and the `initDateTimeChooser(...)` script that was previously missing