### PR TITLE
Record every resource download instead of one row per book

### DIFF
--- a/salesforce/serializers.py
+++ b/salesforce/serializers.py
@@ -131,30 +131,36 @@ class SalesforceFormsSerializer(serializers.ModelSerializer):
 
 
 class ResourceDownloadSerializer(serializers.ModelSerializer):
+    # A reader coming back to the same thing updates that row's last access;
+    # a different resource, or a different format of the same book, is its own
+    # row. first() rather than get() because nothing stops the table from
+    # already holding duplicates.
     def create(self, validated_data):
-        book = validated_data.get('book', None)
-        book_format = validated_data.get('book_format', None)
-        account_uuid = validated_data.get('account_uuid', None)
-        resource_name = validated_data.get('resource_name', None)
-        contact_id = validated_data.get('contact_id', None)
-        rd = []
-        try:
-            rd = ResourceDownload.objects.filter(account_uuid=account_uuid, book=book)
-            if resource_name:
-                rd.filter(resource_name=resource_name)
+        existing = ResourceDownload.objects.filter(
+            account_uuid=validated_data.get('account_uuid'),
+            book=validated_data.get('book'),
+            book_format=validated_data.get('book_format'),
+            resource_name=validated_data.get('resource_name'),
+        ).first()
 
-            rd = rd[0]
-            rd.contact_id = contact_id
-            rd.save()
-        except (ResourceDownload.DoesNotExist, IndexError):
-            rd = ResourceDownload.objects.create(**validated_data)
+        if not existing:
+            return ResourceDownload.objects.create(**validated_data)
 
-        return rd
+        contact_id = validated_data.get('contact_id')
+
+        existing.last_access = validated_data.get('last_access', existing.last_access)
+        # Signed-in students have no Salesforce contact, so an incoming
+        # download without one must not erase a contact we already know.
+        if contact_id:
+            existing.contact_id = contact_id
+        existing.save()
+
+        return existing
 
     class Meta:
         model = ResourceDownload
         fields = ('id', 'book', 'book_format', 'account_uuid', 'contact_id', 'last_access', 'resource_name', 'created')
-        read_only_fields = ('id', 'created', 'last_access', 'number_of_times_accessed')
+        read_only_fields = ('id', 'created', 'last_access')
 
 
 class SavingsNumberSerializer(serializers.ModelSerializer):

--- a/salesforce/serializers.py
+++ b/salesforce/serializers.py
@@ -133,15 +133,16 @@ class SalesforceFormsSerializer(serializers.ModelSerializer):
 class ResourceDownloadSerializer(serializers.ModelSerializer):
     # A reader coming back to the same thing updates that row's last access;
     # a different resource, or a different format of the same book, is its own
-    # row. first() rather than get() because nothing stops the table from
-    # already holding duplicates.
+    # row. Rows duplicated by the pre-fix behaviour are still in the table and
+    # nothing constrains against them, so this takes the most recently accessed
+    # match rather than get()-ing and raising.
     def create(self, validated_data):
         existing = ResourceDownload.objects.filter(
             account_uuid=validated_data.get('account_uuid'),
             book=validated_data.get('book'),
             book_format=validated_data.get('book_format'),
             resource_name=validated_data.get('resource_name'),
-        ).first()
+        ).order_by('-last_access').first()
 
         if not existing:
             return ResourceDownload.objects.create(**validated_data)

--- a/salesforce/tests.py
+++ b/salesforce/tests.py
@@ -473,32 +473,20 @@ class ResourceDownloadTest(TestCase):
         cls.test_doc = Document.objects.create(title='Test Doc', file=test_image)
 
     def test_resource_download_post(self):
-        root_page = Page.objects.get(title="Root")
-        book_index = BookIndex.objects.all()[0]
-        book = Book(title="University Physics",
-                    slug="university-physics",
-                    cnx_id='031da8d3-b525-429c-80cf-6c8ed997733a',
-                    salesforce_book_id='',
-                    description="Test Book",
-                    cover=self.test_doc,
-                    title_image=self.test_doc,
-                    publish_date=datetime.date.today(),
-                    locale=root_page.locale
-                    )
-        book_index.add_child(instance=book)
-        data = {
-            "book": book.pk,
-            "book_format": "PDF",
-            "account_uuid": "310bb96b-0df8-4d10-a759-c7d366c1f524",
-            "resource_name": "Book PDF",
-            "contact_id": "0032f00003zYVdSAAZ"
-            }
-        response = self.client.post('/apps/cms/api/salesforce/download-tracking/', data, format='json')
+        book = self.make_book()
+
+        response = self.post_download(
+            book=book.pk,
+            book_format="PDF",
+            resource_name="Book PDF",
+            contact_id="0032f00003zYVdSAAZ",
+        )
+
         self.assertEqual("PDF", response.data['book_format'])
 
     def make_book(self, title="University Physics", slug="university-physics"):
         root_page = Page.objects.get(title="Root")
-        book_index = BookIndex.objects.all()[0]
+        book_index = BookIndex.objects.first()
         book = Book(title=title,
                     slug=slug,
                     cnx_id='031da8d3-b525-429c-80cf-6c8ed997733a',
@@ -552,6 +540,23 @@ class ResourceDownloadTest(TestCase):
 
         self.assertEqual(1, ResourceDownload.objects.count())
         self.assertGreater(ResourceDownload.objects.get().last_access, original_access)
+
+    def test_updates_the_newest_of_the_rows_the_old_behaviour_duplicated(self):
+        book = self.make_book()
+        account_uuid = "310bb96b-0df8-4d10-a759-c7d366c1f524"
+        common = dict(account_uuid=account_uuid, book=book, resource_name="Test Bank")
+        older = ResourceDownload.objects.create(
+            last_access=datetime.datetime(2020, 1, 1, tzinfo=datetime.timezone.utc), **common)
+        newer = ResourceDownload.objects.create(
+            last_access=datetime.datetime(2021, 1, 1, tzinfo=datetime.timezone.utc), **common)
+
+        self.post_download(book=book.pk, resource_name="Test Bank")
+
+        older.refresh_from_db()
+        newer.refresh_from_db()
+        self.assertEqual(datetime.datetime(2020, 1, 1, tzinfo=datetime.timezone.utc), older.last_access)
+        self.assertGreater(newer.last_access, datetime.datetime(2021, 1, 1, tzinfo=datetime.timezone.utc))
+        self.assertEqual(2, ResourceDownload.objects.count())
 
     def test_a_download_without_a_contact_keeps_the_one_already_known(self):
         book = self.make_book()

--- a/salesforce/tests.py
+++ b/salesforce/tests.py
@@ -12,7 +12,7 @@ from django.conf import settings
 from books.models import BookIndex, Book
 from donations.models import ThankYouNote
 from pages.models import RootPage
-from salesforce.models import SalesforceSettings, MapBoxDataset, Partner, AdoptionOpportunityRecord, SalesforceForms, School
+from salesforce.models import SalesforceSettings, MapBoxDataset, Partner, AdoptionOpportunityRecord, SalesforceForms, School, ResourceDownload
 from salesforce.management.commands.update_opportunities import Command as UpdateOpportunitiesCommand
 from salesforce.salesforce import Salesforce as SF
 from salesforce.serializers import PartnerSerializer
@@ -495,3 +495,68 @@ class ResourceDownloadTest(TestCase):
             }
         response = self.client.post('/apps/cms/api/salesforce/download-tracking/', data, format='json')
         self.assertEqual("PDF", response.data['book_format'])
+
+    def make_book(self, title="University Physics", slug="university-physics"):
+        root_page = Page.objects.get(title="Root")
+        book_index = BookIndex.objects.all()[0]
+        book = Book(title=title,
+                    slug=slug,
+                    cnx_id='031da8d3-b525-429c-80cf-6c8ed997733a',
+                    salesforce_book_id='',
+                    description="Test Book",
+                    cover=self.test_doc,
+                    title_image=self.test_doc,
+                    publish_date=datetime.date.today(),
+                    locale=root_page.locale
+                    )
+        book_index.add_child(instance=book)
+        return book
+
+    def post_download(self, **overrides):
+        data = {
+            "account_uuid": "310bb96b-0df8-4d10-a759-c7d366c1f524",
+            }
+        data.update(overrides)
+        return self.client.post('/apps/cms/api/salesforce/download-tracking/', data, format='json')
+
+    def test_each_resource_of_a_book_is_recorded_separately(self):
+        book = self.make_book()
+
+        self.post_download(book=book.pk, resource_name="Instructor Answer Guide")
+        self.post_download(book=book.pk, resource_name="Test Bank")
+
+        self.assertEqual(
+            {"Instructor Answer Guide", "Test Bank"},
+            set(ResourceDownload.objects.values_list('resource_name', flat=True)),
+        )
+
+    def test_each_format_of_a_book_is_recorded_separately(self):
+        book = self.make_book()
+
+        self.post_download(book=book.pk, book_format="Online")
+        self.post_download(book=book.pk, book_format="PDF")
+
+        self.assertEqual(
+            {"Online", "PDF"},
+            set(ResourceDownload.objects.values_list('book_format', flat=True)),
+        )
+
+    def test_downloading_the_same_resource_again_updates_last_access(self):
+        book = self.make_book()
+
+        self.post_download(book=book.pk, resource_name="Test Bank")
+        first = ResourceDownload.objects.get()
+        original_access = first.last_access
+
+        self.post_download(book=book.pk, resource_name="Test Bank")
+
+        self.assertEqual(1, ResourceDownload.objects.count())
+        self.assertGreater(ResourceDownload.objects.get().last_access, original_access)
+
+    def test_a_download_without_a_contact_keeps_the_one_already_known(self):
+        book = self.make_book()
+
+        self.post_download(book=book.pk, resource_name="Test Bank", contact_id="0032f00003zYVdSAAZ")
+        self.post_download(book=book.pk, resource_name="Test Bank")
+
+        self.assertEqual("0032f00003zYVdSAAZ", ResourceDownload.objects.get().contact_id)


### PR DESCRIPTION
## Problem

`ResourceDownloadSerializer.create` deduped on `(account_uuid, book)` alone. The line meant to narrow that by resource threw its own result away:

```python
rd = ResourceDownload.objects.filter(account_uuid=account_uuid, book=book)
if resource_name:
    rd.filter(resource_name=resource_name)   # queryset discarded
rd = rd[0]
```

`QuerySet.filter` returns a new queryset; it does not mutate. So the narrowing never happened, and a reader who downloaded a second resource for the same book — or viewed a book online and then downloaded its PDF — updated the first row instead of getting their own.

**One row per account per book was all this table could ever hold.** Per-resource and per-format download counts were not recoverable from it.

Two smaller bugs sat in the same method:

- A repeat download never advanced `last_access`. The field recorded *first* access, despite its name and despite the viewset setting it on every POST.
- `contact_id` was overwritten unconditionally, so a download carrying no Salesforce contact erased one already stored.

That last one is about to matter. openstax/os-webview#2961 fixes the frontend so downloads are reported for **any signed-in account**, not only confirmed faculty — students have no Salesforce contact, so on `main` those downloads would begin clearing the contact ids of faculty rows.

## Changes

The lookup now includes `book_format` and `resource_name`, so each distinct thing a reader takes gets its own row, and returning to the same one refreshes it. `last_access` advances on a repeat. An incoming download with no `contact_id` leaves the stored one alone.

`.first()` rather than `.get()` because nothing constrains this table against duplicates and production may already hold some — the old code tolerated that via `[0]` and this keeps tolerating it.

No migration: the model already has both columns and no unique constraint, and existing rows stay valid.

Also drops `number_of_times_accessed` from `read_only_fields` — no such field exists on the model.

## Test plan

Four tests, one per behavior, all in `ResourceDownloadTest`:

- each resource of a book is recorded separately
- each format of a book is recorded separately
- downloading the same resource again updates `last_access` and adds no row
- a download without a contact keeps the one already known

Each fails on `main` and passes here. Full suite: **529 tests, all passing** (`manage.py test --settings=openstax.settings.test`). Note a stale `test_oscms_test` database produces ~150 unrelated site-fixture errors — run with `--noinput` rather than `--keepdb` to reproduce a clean result.

## Worth deciding separately

With dedupe working, a row now means "this account took this resource at least once," and `last_access` says when they last did. If the goal is **total** downloads rather than unique ones, that needs either a counter column or one row per event — a data-model decision, so I left the existing upsert intent intact rather than changing what the numbers mean. The dead `number_of_times_accessed` reference suggests someone once intended the counter.
