### PR TITLE
Serve K12 subject-group pages to crawlers at /k12/<subject>

### DIFF
--- a/openstax/middleware.py
+++ b/openstax/middleware.py
@@ -137,7 +137,9 @@ class CommonMiddlewareOpenGraphRedirect(CommonMiddleware):
             return self.page_by_slug(page_slug)
 
     def build_template(self, page, page_url):
-        page_url = page_url.rstrip('/')
+        # canonical and og:url point at the clean URL so query-string
+        # variants consolidate their signal onto one page
+        page_url = page_url.split('?', 1)[0].rstrip('/')
         image_url = self.image_url(page.promote_image)
         # Use seo_title if available, otherwise fall back to title
         display_title = page.seo_title if page.seo_title else page.title

--- a/openstax/middleware.py
+++ b/openstax/middleware.py
@@ -67,9 +67,9 @@ class CommonMiddlewareOpenGraphRedirect(CommonMiddleware):
     OG_USER_AGENTS = {
         'baiduspider', 'bingbot', 'embedly', 'facebookbot', 'facebookexternalhit/1.1',
         'facebookexternalhit', 'facebot', 'google.*snippet', 'googlebot', 'linkedinbot',
-        'MetadataScraper', 'outbrain', 'pinterest', 'pinterestbot', 'quora', 'quora link preview',
-        'rogerbot', 'showyoubot', 'slackbot', 'slackbot-linkexpanding', 'twitterbot', 'vkShare',
-        'W3C_Validator', 'WhatsApp', 'yandex', 'yahoo',
+        'metadatascraper', 'outbrain', 'pinterest', 'pinterestbot', 'quora', 'quora link preview',
+        'rogerbot', 'showyoubot', 'slackbot', 'slackbot-linkexpanding', 'twitterbot', 'vkshare',
+        'w3c_validator', 'whatsapp', 'yandex', 'yahoo',
         'gptbot', 'perplexitybot', 'applebot',
         'oai-searchbot', 'claudebot', 'claude-searchbot',
     }
@@ -93,7 +93,7 @@ class CommonMiddlewareOpenGraphRedirect(CommonMiddleware):
                 substring in raw_user_agent.lower() for substring in self.AI_CRAWLER_USER_AGENT_SUBSTRINGS
             )
             if is_og_user_agent:
-                url_path = unquote(request.get_full_path()[:-1])
+                url_path = unquote(request.path_info.rstrip('/'))
                 full_url = unquote(request.build_absolute_uri())
                 page_slug = "home" if url_path == '' else url_path.rsplit('/', 1)[-1]
 

--- a/openstax/middleware.py
+++ b/openstax/middleware.py
@@ -11,7 +11,7 @@ from api.models import FeatureFlag
 from books.models import Book, BookIndex
 from openstax.functions import build_image_url
 from news.models import NewsArticle
-from pages.models import Supporters, PrivacyPolicy, K12Subject, Subject, Subjects, RootPage
+from pages.models import Supporters, PrivacyPolicy, K12Subject, Subject, Subjects, RootPage, FlexPage
 
 
 class CommonMiddlewareAppendSlashWithoutRedirect(CommonMiddleware):
@@ -69,16 +69,30 @@ class CommonMiddlewareOpenGraphRedirect(CommonMiddleware):
         'facebookexternalhit', 'facebot', 'google.*snippet', 'googlebot', 'linkedinbot',
         'MetadataScraper', 'outbrain', 'pinterest', 'pinterestbot', 'quora', 'quora link preview',
         'rogerbot', 'showyoubot', 'slackbot', 'slackbot-linkexpanding', 'twitterbot', 'vkShare',
-        'W3C_Validator', 'WhatsApp', 'yandex', 'yahoo'
+        'W3C_Validator', 'WhatsApp', 'yandex', 'yahoo',
+        'gptbot', 'perplexitybot', 'applebot',
+        'oai-searchbot', 'claudebot', 'claude-searchbot',
     }
+
+    # ua_parser doesn't resolve these AI crawlers to a stable family
+    # (e.g. ChatGPT-User parses as family "com/bot"), so they're matched
+    # as raw substrings, mirroring the nginx user-agent map.
+    AI_CRAWLER_USER_AGENT_SUBSTRINGS = (
+        'chatgpt-user', 'google-extended', 'anthropic-ai', 'claude-web',
+        'claude-user', 'perplexity-user',
+    )
 
     def __init__(self, get_response):
         self.get_response = get_response
 
     def __call__(self, request, *args, **kwargs):
         if 'HTTP_USER_AGENT' in request.META:
-            user_agent = user_agent_parser.ParseUserAgent(request.META["HTTP_USER_AGENT"])
-            if user_agent['family'].lower() in self.OG_USER_AGENTS:
+            raw_user_agent = request.META['HTTP_USER_AGENT']
+            user_agent = user_agent_parser.ParseUserAgent(raw_user_agent)
+            is_og_user_agent = user_agent['family'].lower() in self.OG_USER_AGENTS or any(
+                substring in raw_user_agent.lower() for substring in self.AI_CRAWLER_USER_AGENT_SUBSTRINGS
+            )
+            if is_og_user_agent:
                 url_path = unquote(request.get_full_path()[:-1])
                 full_url = unquote(request.build_absolute_uri())
                 page_slug = "home" if url_path == '' else url_path.rsplit('/', 1)[-1]
@@ -89,7 +103,13 @@ class CommonMiddlewareOpenGraphRedirect(CommonMiddleware):
 
                     page = self.get_page(url_path, page_slug)
                     if page:
-                        template = self.build_template(page[0], full_url)
+                        instance = page[0]
+                        # answer-engine crawlers don't execute JS and can only cite
+                        # what's in the raw HTML, so FlexPages serve their full
+                        # content-bearing template
+                        if isinstance(instance, FlexPage):
+                            return instance.serve(request).render()
+                        template = self.build_template(instance, full_url)
                         return HttpResponse(template)
         return self.get_response(request)
 
@@ -101,7 +121,8 @@ class CommonMiddlewareOpenGraphRedirect(CommonMiddleware):
         elif '/privacy' in url_path:
             return PrivacyPolicy.objects.filter(slug='privacy-policy')
         elif '/k12' in url_path:
-            return K12Subject.objects.filter(slug='k12-' + page_slug)
+            return (K12Subject.objects.filter(slug='k12-' + page_slug)
+                    or FlexPage.objects.filter(slug='k12-' + page_slug))
         elif '/subjects' in url_path:
             flag = FeatureFlag.objects.filter(name='new_subjects')
             if flag[0].feature_active:

--- a/openstax/tests.py
+++ b/openstax/tests.py
@@ -333,8 +333,9 @@ class TestOpenGraphMiddleware(TestCase):
     def test_non_flexpage_og_case_still_uses_build_template(self):
         """A non-FlexPage OG match (e.g. book) serves the build_template snapshot;
         the full-template path is FlexPage-only."""
-        test_image = SimpleUploadedFile(name='openstax.png',
-                                        content=open("pages/static/images/openstax.png", 'rb').read())
+        with open("pages/static/images/openstax.png", 'rb') as image_file:
+            image_content = image_file.read()
+        test_image = SimpleUploadedFile(name='openstax.png', content=image_content)
         self.test_doc = Document.objects.create(title='Test Doc', file=test_image)
         book_index = BookIndex(title="Book Index",
                                page_description="Test",

--- a/openstax/tests.py
+++ b/openstax/tests.py
@@ -251,6 +251,14 @@ class TestOpenGraphMiddleware(TestCase):
         self.assertContains(response, 'twitter:title')
         self.assertContains(response, 'OpenStax Home')
 
+    def test_snapshot_canonical_url_has_no_query_string(self):
+        """Query-string variants (e.g. utm parameters) declare the clean URL
+        as canonical so their signal consolidates onto one page."""
+        response = self.client.get('/?utm_source=chatgpt.com&utm_medium=referral')
+        self.assertContains(response, 'rel="canonical" href="http://testserver"')
+        self.assertContains(response, 'og:url" content="http://testserver"')
+        self.assertNotContains(response, 'utm_source')
+
     def test_k12_flexpage_link_preview(self):
         """K12 subject-group pages are FlexPages (e.g. k12-math), not K12Subjects.
         The middleware should fall back to FlexPage when no K12Subject matches."""

--- a/openstax/tests.py
+++ b/openstax/tests.py
@@ -7,7 +7,7 @@ from django.http import HttpResponse, HttpResponseNotFound
 from django.core.files.uploadedfile import SimpleUploadedFile
 from openstax.middleware import CommonMiddlewareAppendSlashWithoutRedirect
 from wagtail.models import Page
-from pages.models import RootPage
+from pages.models import RootPage, FlexPage
 from books.models import BookIndex, Book
 from news.models import NewsIndex, NewsArticle
 from snippets.models import Subject, BlogContentType, BlogCollection
@@ -250,4 +250,116 @@ class TestOpenGraphMiddleware(TestCase):
         # Should use seo_title in twitter:title meta tag
         self.assertContains(response, 'twitter:title')
         self.assertContains(response, 'OpenStax Home')
+
+    def test_k12_flexpage_link_preview(self):
+        """K12 subject-group pages are FlexPages (e.g. k12-math), not K12Subjects.
+        The middleware should fall back to FlexPage when no K12Subject matches."""
+        self.k12_math = FlexPage(title="Math",
+                                 slug="k12-math",
+                                 seo_title='K12 Math SEO Title',
+                                 search_description='K12 Math page description')
+        self.homepage.add_child(instance=self.k12_math)
+        self.client = Client(HTTP_USER_AGENT='facebookexternalhit/1.1')
+        response = self.client.get('/k12/math/')
+        self.assertContains(response, 'og:image')
+        self.assertContains(response, 'K12 Math SEO Title')
+
+    def test_ai_crawler_gets_og_page(self):
+        """AI crawlers (GPTBot etc.) must get the OG snapshot too, not Wagtail's
+        404 -- their real UA strings don't always resolve to a stable ua_parser
+        family, so the middleware also checks for them by raw substring."""
+        self.k12_math = FlexPage(title="Math",
+                                 slug="k12-math",
+                                 seo_title='K12 Math SEO Title',
+                                 search_description='K12 Math page description')
+        self.homepage.add_child(instance=self.k12_math)
+        self.client = Client(HTTP_USER_AGENT=(
+            'Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko); compatible; '
+            'GPTBot/1.1; +https://openai.com/gptbot'
+        ))
+        response = self.client.get('/k12/math/')
+        self.assertContains(response, 'og:image')
+        self.assertContains(response, 'K12 Math SEO Title')
+
+    def test_claudebot_gets_og_page(self):
+        """ClaudeBot (Anthropic's training crawler) resolves to a stable ua_parser
+        family and must get the OG page like the other current-generation AI
+        crawlers nginx now routes through."""
+        self.k12_math = FlexPage(title="Math",
+                                 slug="k12-math",
+                                 seo_title='K12 Math SEO Title',
+                                 search_description='K12 Math page description')
+        self.homepage.add_child(instance=self.k12_math)
+        self.client = Client(HTTP_USER_AGENT=(
+            'Mozilla/5.0 (compatible; ClaudeBot/1.0; +claudebot@anthropic.com)'
+        ))
+        response = self.client.get('/k12/math/')
+        self.assertContains(response, 'og:image')
+        self.assertContains(response, 'K12 Math SEO Title')
+
+    def test_human_user_agent_does_not_get_og_page(self):
+        """A normal browser UA must not be served the bot-only OG snapshot."""
+        self.k12_math = FlexPage(title="Math",
+                                 slug="k12-math",
+                                 seo_title='K12 Math SEO Title',
+                                 search_description='K12 Math page description')
+        self.homepage.add_child(instance=self.k12_math)
+        self.client = Client(HTTP_USER_AGENT=(
+            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 '
+            '(KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36'
+        ))
+        response = self.client.get('/k12/math/')
+        self.assertNotContains(response, 'K12 Math SEO Title', status_code=404)
+
+    def test_k12_flexpage_serves_real_template_with_jsonld(self):
+        """Answer-engine crawlers don't execute JS and can only cite text in the
+        raw HTML, so k12 FlexPages serve their full content-bearing template
+        with JSON-LD."""
+        self.k12_math = FlexPage(title="Math",
+                                 slug="k12-math",
+                                 seo_title='K12 Math SEO Title',
+                                 search_description='K12 Math page description')
+        self.homepage.add_child(instance=self.k12_math)
+        self.client = Client(HTTP_USER_AGENT='facebookexternalhit/1.1')
+        response = self.client.get('/k12/math/')
+        self.assertContains(response, 'K12 Math SEO Title')
+        self.assertContains(response, 'application/ld+json')
+        self.assertContains(response, '"@type": "CollectionPage"')
+        self.assertContains(response, 'og:site_name')
+        self.assertContains(response, 'og:type" content="website"')
+        self.assertContains(response, f'og:url" content="{self.k12_math.get_full_url()}"')
+        self.assertContains(response, f'href="{self.k12_math.get_full_url()}"')
+
+    def test_non_flexpage_og_case_still_uses_build_template(self):
+        """A non-FlexPage OG match (e.g. book) serves the build_template snapshot;
+        the full-template path is FlexPage-only."""
+        test_image = SimpleUploadedFile(name='openstax.png',
+                                        content=open("pages/static/images/openstax.png", 'rb').read())
+        self.test_doc = Document.objects.create(title='Test Doc', file=test_image)
+        book_index = BookIndex(title="Book Index",
+                               page_description="Test",
+                               dev_standard_1_description="Test",
+                               dev_standard_2_description="Test",
+                               dev_standard_3_description="Test",
+                               dev_standard_4_description="Test",
+                               )
+        self.homepage.add_child(instance=book_index)
+        book = Book(title="Biology 2e",
+                    slug="biology-2e-build-template-check",
+                    cnx_id='031da8d3-b525-429c-80cf-6c8ed997733a',
+                    description="Test Book",
+                    cover=self.test_doc,
+                    title_image=self.test_doc,
+                    publish_date=datetime.date.today(),
+                    locale=self.root_page.locale,
+                    license_name='Creative Commons Attribution License',
+                    seo_title='Biology 2e',
+                    search_description='2nd edition of Biology'
+                    )
+        book_index.add_child(instance=book)
+        self.client = Client(HTTP_USER_AGENT='Slackbot-LinkExpanding 1.0 (+https://api.slack.com/robots)')
+        response = self.client.get('/details/books/biology-2e-build-template-check/')
+        self.assertContains(response, 'og:image')
+        self.assertContains(response, '<body></body>')
+        self.assertNotContains(response, 'application/ld+json')
 

--- a/pages/models/core.py
+++ b/pages/models/core.py
@@ -167,6 +167,11 @@ class FlexPage(RootPage):
             return None
 
         site_id, site_root_url, page_url_relative_to_site_root = url_parts
+
+        # the osweb SPA serves these at /k12/<subject> (see os-webview page-routes)
+        if self.slug.startswith('k12-'):
+            return site_id, site_root_url, '/k12/{}'.format(self.slug.removeprefix('k12-'))
+
         return site_id, site_root_url, '/{}'.format(self.slug)
 
 

--- a/pages/templates/page.html
+++ b/pages/templates/page.html
@@ -9,10 +9,11 @@
     <title>{{ page.seo_title|default:page.title }}</title>
     <meta name="description" content="{{ page.search_description }}">
     <link rel="canonical" href="{{page.get_full_url}}" />
-    <meta http-equiv="refresh">
 
     <meta property="og:url" content="{{page.get_full_url}}" />
-    <meta property="og:type" content="article" />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="OpenStax" />
+    <meta property="og:locale" content="en_US" />
     <meta property="og:title" content="{{ page.seo_title|default:page.title }}" />
     <meta property="og:description" content="{{ page.search_description }}" />
     <meta property="og:image" content="{{ promote_image.url }}" />
@@ -24,6 +25,24 @@
     <meta name="twitter:description" content="{{ page.search_description }}">
     <meta name="twitter:image" content="{{ promote_image.url }}">
     <meta name="twitter:image:alt" content="OpenStax">
+
+    {% if page.slug|slice:":4" == "k12-" %}
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "CollectionPage",
+      "name": "{{ page.title|escapejs }}",
+      "url": "{{ page.get_full_url }}",
+      "description": "{{ page.search_description|escapejs }}",
+      "isPartOf": {"@type": "WebSite", "name": "OpenStax", "url": "https://openstax.org"},
+      "publisher": {"@type": "EducationalOrganization", "name": "OpenStax", "url": "https://openstax.org"},
+      "breadcrumb": {"@type": "BreadcrumbList", "itemListElement": [
+        {"@type": "ListItem", "position": 1, "name": "K12", "item": "https://openstax.org/k12"},
+        {"@type": "ListItem", "position": 2, "name": "{{ page.title|escapejs }}", "item": "{{ page.get_full_url }}"}
+      ]}
+    }
+    </script>
+    {% endif %}
 </head>
 <body>
 {% block content %}

--- a/pages/tests/test_link_resolution.py
+++ b/pages/tests/test_link_resolution.py
@@ -8,6 +8,7 @@ from wagtail.api import APIField
 from books.models import Book
 from openstax.api_fields import APIRichTextBlock, ExpandedRichTextField, strip_empty_paragraphs
 from pages.custom_blocks import AssignableBookBlock, LinksGroupBlock
+from pages.models import FlexPage
 from pages.shared_blocks import LinkBlock
 
 
@@ -125,6 +126,34 @@ class ModelRichTextWiringTests(TestCase):
                 if isinstance(e, APIField) and e.name == 'resource_description'
             )
             self.assertIsInstance(entry.serializer, ExpandedRichTextField)
+
+
+class FlexPageUrlTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        root = Page.objects.get(id=1)
+        site, _ = Site.objects.get_or_create(
+            hostname="localhost", defaults={"root_page": root, "is_default_site": True}
+        )
+        site.root_page = root
+        site.save()
+        Site.clear_site_root_paths_cache()
+        cls.k12_math = FlexPage(title="Math", slug="k12-math")
+        root.add_child(instance=cls.k12_math)
+        cls.about = FlexPage(title="About", slug="about-us")
+        root.add_child(instance=cls.about)
+
+    def test_k12_flexpage_url_uses_k12_prefix(self):
+        # k12 subject-group FlexPages are served by the osweb SPA at /k12/<subject>,
+        # not the flat /k12-math tree slug.
+        _, _, path = self.k12_math.get_url_parts()
+        self.assertEqual(path, '/k12/math')
+        self.assertEqual(self.k12_math.url, '/k12/math')
+
+    def test_non_k12_flexpage_url_is_flat(self):
+        _, _, path = self.about.get_url_parts()
+        self.assertEqual(path, '/about-us')
+        self.assertEqual(self.about.url, '/about-us')
 
 
 class LinkBlockTargetTests(TestCase):


### PR DESCRIPTION
## What

Four related changes so the new K12 subject-group pages (FlexPages with slugs `k12-math`, `k12-science`, `k12-social-studies`, `k12-cte`) work correctly at their canonical `/k12/<subject>` URLs:

1. **URL resolution** — `FlexPage.get_url_parts` maps `k12-` slugs to `/k12/<subject>`. This flows into everything Wagtail generates from page URLs: internal page-chooser links, the API's `html_url`, and sitemap.xml. It matches the convention `K12Subject.get_url_parts` already uses for the legacy per-subject pages.
2. **Crawler page lookup** — the OG middleware's `/k12` branch falls back to a FlexPage lookup when no `K12Subject` matches, so crawlers get a page at `/k12/<subject>` for the group pages.
3. **Crawler coverage** — the middleware now matches the current generation of AI crawlers. Each user agent was tested empirically through `ua_parser`: products with stable families (GPTBot, PerplexityBot, Applebot, OAI-SearchBot, ClaudeBot, Claude-SearchBot) join `OG_USER_AGENTS`; products that don't parse to a stable family (ChatGPT-User parses as family `com/bot`; Claude-User, Perplexity-User, Google-Extended, anthropic-ai, claude-web parse inconsistently) are matched as raw substrings, mirroring the nginx user-agent map that routes them here.
4. **Citable content** — FlexPage matches serve their full `page.html` render (H1 + real page text) rather than the empty-body meta snapshot. Answer-engine crawlers do not execute JavaScript and can only cite text present in the raw HTML. `page.html` also gains JSON-LD (`CollectionPage` + `BreadcrumbList`) for `k12-` pages, `og:type=website`, `og:site_name`, and `og:locale`; a dead `<meta http-equiv="refresh">` with no content attribute is removed. Non-FlexPage crawler pages (books, blog, etc.) are unchanged, covered by a regression test.

## Why

Verified live before the change: Googlebot and GPTBot both receive **404** for `/k12-math` — the new pages are invisible to search engines and answer engines. The flat flex slugs can't be resolved by Wagtail's tree routing (the pages live under the k12 page in the tree), and the middleware only knew the legacy `K12Subject` model.

## Verification

- `python3 manage.py test openstax.tests.TestOpenGraphMiddleware` — 11 tests, including: crawler UAs get the page at `/k12/math/`, a normal browser UA does not, JSON-LD and canonical URL present, book pages keep their existing snapshot output.
- Full `pages` suite green; `makemigrations --check` clean (no model fields changed).

## Deploy notes

Deploy **after** the os-webview release that serves `/k12/<subject>` — page-chooser links and sitemap entries start emitting the new URLs as soon as this lands. Companion PRs linked below.

## Companion PRs

- os-webview (SPA route, deploy first): https://github.com/openstax/os-webview/pull/2975
- bit-deployment (301s + crawler map): https://github.com/openstax/bit-deployment/pull/168
