### PR TITLE
Cap blog search terms and drop the per-article queries

### DIFF
--- a/news/search.py
+++ b/news/search.py
@@ -28,9 +28,11 @@ def search(request):
     collection = request.GET.get('collection', '').strip()
     content_types = _csv_param(request, 'types')
     sort = request.GET.get('sort', 'relevance').strip()
+    q = ' '.join(
+        token for token in re.split(r'[\s\-]+', q)[:MAX_SEARCH_TERMS] if token
+    )
 
     if q:
-        q = ' '.join(re.split(r'[\s\-]+', q)[:MAX_SEARCH_TERMS])
         results = _live_articles().search(q)
     elif tag:
         results = _live_articles().filter(

--- a/news/search.py
+++ b/news/search.py
@@ -1,12 +1,24 @@
+import re
 
 from django.http import JsonResponse
 
 from news.models import NewsArticle
 
+# The Postgres backend nests one expression per whitespace/hyphen-separated
+# term, and Django recurses that tree when hashing it — past ~150 terms a query
+# raises RecursionError instead of returning results.
+MAX_SEARCH_TERMS = 25
+
 
 def _csv_param(request, name):
     raw = request.GET.get(name, '').strip()
     return [v.strip() for v in raw.split(',') if v.strip()]
+
+
+def _live_articles():
+    return NewsArticle.objects.live() \
+        .select_related('featured_image') \
+        .prefetch_related('tags')
 
 
 def search(request):
@@ -18,13 +30,14 @@ def search(request):
     sort = request.GET.get('sort', 'relevance').strip()
 
     if q:
-        results = NewsArticle.objects.live().search(q)
+        q = ' '.join(re.split(r'[\s\-]+', q)[:MAX_SEARCH_TERMS])
+        results = _live_articles().search(q)
     elif tag:
-        results = NewsArticle.objects.filter(
-            tags__name__in=[tag], live=True
+        results = _live_articles().filter(
+            tags__name__in=[tag]
         ).order_by('-date').distinct()
     else:
-        results = NewsArticle.objects.filter(live=True).order_by('-date')
+        results = _live_articles().order_by('-date')
 
     articles = list(results)
     if subjects:
@@ -58,7 +71,7 @@ def search(request):
             'date': result.date,
             'author': result.author,
             'pin_to_top': result.pin_to_top,
-            'tags': list(result.tags.names()),
+            'tags': [t.name for t in result.tags.all()],
             'collections': result.blog_collections,
             'article_subjects': result.blog_subjects,
             'content_types': result.blog_content_types,

--- a/news/tests.py
+++ b/news/tests.py
@@ -8,7 +8,10 @@ from wagtail.models import Page
 from pages.models import RootPage
 from shared.test_utilities import assertPathDoesNotRedirectToTrailingSlash
 from unittest.mock import MagicMock, patch
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 from news.models import NewsIndex, NewsArticle, PressIndex, PressRelease
+from news.search import MAX_SEARCH_TERMS
 from snippets.models import Subject, BlogContentType, BlogCollection
 
 
@@ -446,6 +449,56 @@ class NewsTests(WagtailPageTestCase, TestCase):
             slugs.index('thermo-body-only'),
             "Title-match (older) article should appear before body-only (newer) article when ordered by relevance"
         )
+
+    def test_very_long_query_does_not_blow_the_recursion_limit(self):
+        """A query with more terms than the backend can nest must still return 200."""
+        self._populate_search_index()
+
+        response = self.client.get(
+            '/apps/cms/api/search/',
+            {'q': ' '.join(f'term{i}' for i in range(500))}
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def test_query_is_capped_to_max_search_terms(self):
+        long_query = ' '.join(f'term{i}' for i in range(500))
+
+        with patch('news.search._live_articles') as live_articles:
+            self.client.get('/apps/cms/api/search/', {'q': long_query})
+
+        searched = live_articles.return_value.search.call_args[0][0]
+        self.assertEqual(len(searched.split()), MAX_SEARCH_TERMS)
+
+    def test_result_count_does_not_change_query_count(self):
+        """Serializing images and tags must not run per-article queries."""
+        news_index = NewsIndex.objects.all()[0]
+
+        def article_count_queries():
+            with CaptureQueriesContext(connection) as queries:
+                response = self.client.get('/apps/cms/api/search/')
+                self.assertEqual(response.status_code, 200)
+            return len(json.loads(response.content)), len(queries)
+
+        baseline_articles, baseline_queries = article_count_queries()
+
+        for i in range(5):
+            news_index.add_child(instance=NewsArticle(
+                title=f"N+1 article {i}",
+                slug=f"n-plus-one-{i}",
+                date=timezone.now(),
+                heading="Heading",
+                subheading="Subheading",
+                author="OpenStax",
+                body=json.dumps([{"type": "paragraph", "value": "<p>Body.</p>"}]),
+                article_subjects=json.dumps([]),
+                content_types=json.dumps([]),
+                collections=json.dumps([]),
+            ))
+
+        grown_articles, grown_queries = article_count_queries()
+
+        self.assertEqual(grown_articles, baseline_articles + 5)
+        self.assertEqual(grown_queries, baseline_queries)
 
 
 class PressTests(WagtailPageTestCase):

--- a/news/tests.py
+++ b/news/tests.py
@@ -469,6 +469,15 @@ class NewsTests(WagtailPageTestCase, TestCase):
         searched = live_articles.return_value.search.call_args[0][0]
         self.assertEqual(len(searched.split()), MAX_SEARCH_TERMS)
 
+    def test_degenerate_query_falls_back_to_tag_search(self):
+        with patch('news.search._live_articles') as live_articles:
+            self.client.get('/apps/cms/api/search/', {'q': '---', 'tag': 'Physics'})
+
+        live_articles.return_value.search.assert_not_called()
+        live_articles.return_value.filter.assert_called_once_with(
+            tags__name__in=['Physics']
+        )
+
     def test_result_count_does_not_change_query_count(self):
         """Serializing images and tags must not run per-article queries."""
         news_index = NewsIndex.objects.all()[0]


### PR DESCRIPTION
## What

Two fixes to `/apps/cms/api/search/` (`news/search.py`).

**1. RecursionError on long queries** ([Sentry](https://openstax.sentry.io/), event `8d91d14a`, release v2026.09.02)

The Postgres search backend nests one expression per whitespace/hyphen-separated term (`lexemes &= new_lexeme`), and Django recurses that tree when hashing it. Reproduced locally: 150 terms fine, 200 terms `RecursionError`. Someone submitted a ~150+ word `q` and got a 500. Now capped at 25 terms.

**2. A query per article**

Every result fetched `featured_image` (FK) and `tags` (`.names()` always requeries, even prefetched) individually. Confirmed 1 extra query per article. This hits hardest on the *no-`q`* path, which is what the blog listing, `subjects/new/specific/blog-posts` and the topic carousels all call — they load every live article and filter in Python.

## Tests

Three new tests in `news/tests.py`, all verified to fail without the fix:

- `test_very_long_query_does_not_blow_the_recursion_limit` — 500-term `q`, reproduces the actual `RecursionError` on Postgres
- `test_query_is_capped_to_max_search_terms`
- `test_result_count_does_not_change_query_count` — adding 5 articles was `9 != 4` queries before, constant now

Full suite: 572 tests, all passing.

## Not in scope

The endpoint still returns *every* matching article unpaginated, and `?subjects=`/`?collection=` filter in Python after loading them all. Fixing either means changing the contract with os-webview (which paginates client-side), so leaving it.