### PR TITLE
Stop 500ing on thank-you notes that omit school

### DIFF
--- a/donations/tests.py
+++ b/donations/tests.py
@@ -183,3 +183,24 @@ class ThankYouNotePostHogTest(APITestCase, TestCase):
             mock_capture.call_args.kwargs['properties']['form_type'],
             'donation_thank_you',
         )
+
+
+class ThankYouNoteFieldFallbackTest(APITestCase, TestCase):
+    """Stale cached SPA bundles post 'institution' instead of 'school' (Sentry OPENSTAX-CMS-WM)."""
+
+    def test_accepts_legacy_institution_field(self):
+        data = {"thank_you_note": "Thanks!", "first_name": "Francis", "last_name": "Martindale",
+                "institution": "Open University", "source": "PDF download"}
+        response = self.client.post('/apps/cms/api/donations/thankyounote/', data)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(ThankYouNote.objects.get(last_name='Martindale').institution, 'Open University')
+
+    def test_missing_optional_fields_do_not_error(self):
+        response = self.client.post('/apps/cms/api/donations/thankyounote/', {"thank_you_note": "Thanks!"})
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(ThankYouNote.objects.get(thank_you_note='Thanks!').institution, '')
+
+    def test_missing_note_returns_400(self):
+        response = self.client.post('/apps/cms/api/donations/thankyounote/', {"first_name": "Bot"})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertFalse(ThankYouNote.objects.exists())

--- a/donations/views.py
+++ b/donations/views.py
@@ -12,27 +12,23 @@ class ThankYouNoteViewSet(viewsets.ModelViewSet):
 
     @action(methods=['post'], detail=True)
     def post(self, request):
-        thank_you_note = request.data['thank_you_note']
-        first_name = request.data['first_name']
-        last_name = request.data['last_name']
-        institution = request.data['school']
-        consent_to_share_or_contact = request.data.get('consent_to_share_or_contact', False)
-        contact_email_address = request.data.get('contact_email_address', '')
-        source = request.data.get('source', '')
-        account_uuid = request.data.get('account_uuid') or None
+        thank_you_note = str(request.data.get('thank_you_note') or '').strip()
+        if not thank_you_note:
+            return JsonResponse(status=400, data={'thank_you_note': 'This field is required.'})
+
+        # 'institution' is the pre-2025 field name, still posted by stale cached SPA bundles
+        institution = request.data.get('school') or request.data.get('institution', '')
 
         ty_note = ThankYouNote.objects.create(thank_you_note=thank_you_note,
-                                              first_name=first_name,
-                                              last_name=last_name,
+                                              first_name=request.data.get('first_name', ''),
+                                              last_name=request.data.get('last_name', ''),
                                               institution=institution,
-                                              consent_to_share_or_contact=consent_to_share_or_contact,
-                                              contact_email_address=contact_email_address,
-                                              source=source,
-                                              account_uuid=account_uuid)
+                                              consent_to_share_or_contact=request.data.get('consent_to_share_or_contact', False),
+                                              contact_email_address=request.data.get('contact_email_address', ''),
+                                              source=request.data.get('source', ''),
+                                              account_uuid=request.data.get('account_uuid') or None)
 
-        serializer = ThankYouNoteSerializer(data=request.data)
-        if serializer.is_valid():
-            return JsonResponse(status=201, data=serializer.data)
+        return JsonResponse(status=201, data=ThankYouNoteSerializer(ty_note).data)
 
 
 class DonationPopupViewSet(viewsets.ModelViewSet):


### PR DESCRIPTION
## Problem

Sentry [OPENSTAX-CMS-WM](https://openstax.sentry.io/issues/7704478184/) — `MultiValueDictKeyError: 'school'` in `ThankYouNoteViewSet.post`.

The give-before-PDF thank-you form used to post `institution`; os-webview [#2707](https://github.com/openstax/os-webview/pull/2707) (Feb 2025) replaced that input with `SchoolSelector`, which posts `school`. The CMS view was switched to `request.data['school']` — so any visitor still running a cached copy of the older bundle gets a 500 and their thank-you note is dropped. The Sentry event is exactly that: a Samsung Internet client posting `institution: Open University`.

## Fix

- Accept `school` or the legacy `institution`.
- `.get()` with blank fallbacks for the other fields, so one missing input is no longer a 500.
- Empty `thank_you_note` → 400 instead of saving a blank row (the endpoint is public and unauthenticated).
- Removed the write-then-validate serializer round-trip: `ThankYouNoteSerializer` is entirely `read_only_fields`, so `serializer.data` was always `{}`, and the `if serializer.is_valid()` branch returned `None` on failure — a second 500 waiting to happen. The 201 now serializes the note that was actually created.

The iframe-target form ignores the response body, so nothing on the frontend needs to change.

## Tests

3 new cases in `donations/tests.py` (legacy `institution` key, missing optional fields, empty note → 400). `python manage.py test donations --settings=openstax.settings.test` → 13 passed.