### PR TITLE
Identify server-side thank-you note events by account UUID

### DIFF
--- a/donations/signals.py
+++ b/donations/signals.py
@@ -27,5 +27,6 @@ def capture_thank_you_note(sender, instance, created, **kwargs):
         return
     posthog_capture(
         'thank_you_note_submitted',
+        distinct_id=instance.account_uuid,
         properties={'form_type': 'donation_thank_you'},
     )

--- a/donations/tests.py
+++ b/donations/tests.py
@@ -183,6 +183,26 @@ class ThankYouNotePostHogTest(APITestCase, TestCase):
             mock_capture.call_args.kwargs['properties']['form_type'],
             'donation_thank_you',
         )
+        self.assertIsNone(mock_capture.call_args.kwargs['distinct_id'])
+
+    @mock.patch('donations.signals.posthog_capture')
+    def test_posthog_event_identifies_signed_in_submitter(self, mock_capture):
+        account_uuid = "11111111-1111-1111-1111-111111111111"
+        data = {
+            "thank_you_note": "Thanks OpenStax!",
+            "last_name": "Reed",
+            "first_name": "Robin",
+            "school": "Rice University",
+            "source": "PDF download",
+            "account_uuid": account_uuid,
+        }
+        response = self.client.post(
+            '/apps/cms/api/donations/thankyounote/', data, format='json'
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(
+            str(mock_capture.call_args.kwargs['distinct_id']), account_uuid
+        )
 
 
 class ThankYouNoteFieldFallbackTest(APITestCase, TestCase):


### PR DESCRIPTION
Follow-up to #1785, from the same investigation.

## Problem

`donations/signals.py` captures `thank_you_note_submitted` on `post_save`, but never passes the note's `account_uuid`:

```python
posthog_capture('thank_you_note_submitted', properties={'form_type': 'donation_thank_you'})
```

`shared.analytics.capture` therefore takes its anonymous branch on every call — a throwaway `uuid4()` distinct_id plus `$process_person_profile: False`. The field was added specifically so a signed-in submission joins the visitor's existing PostHog identity (os-webview [#2909](https://github.com/openstax/os-webview/pull/2909)), and it was being dropped on the floor. All ~7.7k events in the last 14 days are unattributable.

## Fix

Pass `distinct_id=instance.account_uuid`. `capture` already handles `None` by falling back to the anonymous branch, so logged-out submissions behave exactly as before.

## Tests

`donations/tests.py` — the existing PostHog test now asserts `distinct_id is None` for an anonymous post, plus a new case asserting the account UUID is forwarded when present. `shared/test_analytics.py` already covers both branches of `capture`. `manage.py test donations shared` → 19 passed.

## Not in this PR

This event is also a **duplicate name**: GTM Tag 2 emits `thankyou_note_submitted` for the same submission, and action 259398 ("💌 Thank You Note Submitted") matches only the GTM name — so this server-side event is invisible to the dashboard tile, and summing both double counts. Volumes track day-by-day with the server ~7% higher (ad-block loss on the client tag). Consolidating the names needs a GTM-side decision, so it's not bundled here.