### PR TITLE
Emit thank-you notes under the canonical PostHog event name

### DIFF
--- a/docs/posthog-cms-implementation-plan.md
+++ b/docs/posthog-cms-implementation-plan.md
@@ -291,6 +291,9 @@ Expected: PASS (3 tests).
 
 ### Task 4: Capture `thank_you_note_submitted` on donation thank-you creation (TDD)
 
+> Superseded: the event ships as `thankyou_note_submitted`, matching PostHog action 259398
+> and the GTM tag it replaced. Do not reintroduce the underscored spelling.
+
 **Files:**
 - Modify: `donations/signals.py` (import `ThankYouNote`; add receiver)
 - Test: `donations/tests.py` (append)

--- a/donations/signals.py
+++ b/donations/signals.py
@@ -25,8 +25,10 @@ def clear_cloudfront_on_site_banner_save(sender, **kwargs):
 def capture_thank_you_note(sender, instance, created, **kwargs):
     if not created:
         return
+    # Name matches PostHog action 259398, which GTM Tag 2 used to feed. Renaming
+    # this detaches the dashboard tile from every thank-you note.
     posthog_capture(
-        'thank_you_note_submitted',
+        'thankyou_note_submitted',
         distinct_id=instance.account_uuid,
         properties={'form_type': 'donation_thank_you'},
     )

--- a/donations/signals.py
+++ b/donations/signals.py
@@ -25,8 +25,8 @@ def clear_cloudfront_on_site_banner_save(sender, **kwargs):
 def capture_thank_you_note(sender, instance, created, **kwargs):
     if not created:
         return
-    # Name matches PostHog action 259398, which GTM Tag 2 used to feed. Renaming
-    # this detaches the dashboard tile from every thank-you note.
+    # PostHog action 259398 (formerly fed by GTM Tag 2) matches this exact name;
+    # any other spelling drops these notes off the dashboard tile silently.
     posthog_capture(
         'thankyou_note_submitted',
         distinct_id=instance.account_uuid,

--- a/donations/tests.py
+++ b/donations/tests.py
@@ -178,7 +178,7 @@ class ThankYouNotePostHogTest(APITestCase, TestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         mock_capture.assert_called_once()
-        self.assertEqual(mock_capture.call_args.args[0], 'thank_you_note_submitted')
+        self.assertEqual(mock_capture.call_args.args[0], 'thankyou_note_submitted')
         self.assertEqual(
             mock_capture.call_args.kwargs['properties']['form_type'],
             'donation_thank_you',

--- a/shared/test_analytics.py
+++ b/shared/test_analytics.py
@@ -36,7 +36,7 @@ class AnalyticsCaptureTest(TestCase):
     @mock.patch('shared.analytics.Posthog')
     def test_capture_anonymous_disables_person_profile(self, mock_posthog):
         client = mock_posthog.return_value
-        analytics.capture('thank_you_note_submitted')
+        analytics.capture('errata_submitted')
         kwargs = client.capture.call_args.kwargs
         self.assertIs(kwargs['properties']['$process_person_profile'], False)
         self.assertTrue(kwargs['distinct_id'])  # a generated id, not empty


### PR DESCRIPTION
Stacked on #1786 — review that first; the base retargets to `main` once it merges.

## ⚠️ Do not merge until GTM Tag 2 is retired

While both GTM Tag 2 and this code emit `thankyou_note_submitted`, PostHog action 259398 counts every submission **twice**. Turn the tag off first, then merge and deploy.

## Problem

Two event names for one submission:

| Event | Source | Last 14d |
|---|---|---|
| `thankyou_note_submitted` | GTM Tag 2 (`$lib=web`) | 7,210 |
| `thank_you_note_submitted` | `donations/signals.py` (`posthog-python`) | 7,717 |

Action 259398 ("💌 Thank You Note Submitted") matches only the GTM spelling, so the server-side event was invisible to the dashboard tile — and anyone summing both got ~2× reality.

## Fix

Rename the server-side event to the canonical `thankyou_note_submitted`. The server side becomes the single source of truth: it fires on the row that was actually written, so it also catches the ~7% of submissions the client tag loses to ad blockers and JS failures. The action, tile, and any insight built on it keep working with no PostHog-side change.

Also renames an unrelated fixture string in `shared/test_analytics.py` that used the old name as a throwaway label, and marks the superseded name in `docs/posthog-cms-implementation-plan.md` so it isn't reintroduced.

## Attribution

The GTM event carried `book_page` and `utm_source`; the server event does not. I checked every saved insight in the project — none breaks down thank-you notes by either property, so I didn't port them. Adding them later means moving the capture out of the `post_save` signal into the view (the signal has no `request`), which isn't worth doing for an unused breakdown.

## Tests

`manage.py test donations shared` → 19 passed.