### PR TITLE
Rewrite rich text in the OpenStax voice, with context and markup intact

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,6 +148,21 @@ publishes** (a human reviews and publishes in the Wagtail admin).
 Wagtail 7.4 note: prefer **deferred validation** for draft saves (required-field
 checks happen at publish time) and `ImageRenditionField` for headless images.
 
+## AI Authoring Assists (`ai_assist/`)
+
+Wagtail AI integration (wagtail-ai + django-ai-core + any-llm) lives in
+`ai_assist/`; see `ai_assist/README.md` for the whole picture. Two things worth
+knowing before touching it:
+
+- **Two provider stacks.** Rich-text prompts run on the legacy `llm` library
+  (`WAGTAIL_AI["BACKENDS"]`); everything else — title/description, alt text,
+  content feedback, the OpenStax voice rewrite — runs on any-llm
+  (`WAGTAIL_AI["PROVIDERS"]`). New work should use the any-llm path.
+- **OpenStax voice rewrite** is ours, not wagtail-ai's: it round-trips
+  ContentState through Wagtail's `ContentstateConverter` server-side so the
+  field's own feature list survives the rewrite, and briefs the model with the
+  page it is editing.
+
 ## Accessibility Remediation Status
 
 The Accessibility Hub (`/accessibility-hub`) publishes per-ancillary WCAG

--- a/ai_assist/README.md
+++ b/ai_assist/README.md
@@ -5,6 +5,8 @@ django-ai-core + any-llm). Always enabled; the tools only appear in the editor,
 so anyone with Wagtail edit access can use them. Features:
 
 - **Rich-text wand** — rewrite/grammar/completion in rich-text fields.
+- **OpenStax voice rewrite** — a second toolbar button that rewrites the
+  selected blocks with page context, keeping the field's own markup.
 - **Title & meta-description suggestions** — on every page type (`AITitleFieldPanel` / `AIDescriptionFieldPanel`, applied in `panel_patches.py`).
 - **Image alt text** — in the image editor (`WAGTAILIMAGES_IMAGE_FORM_BASE`) and contextually in StreamField image blocks (`AIImageBlock`).
 - **Content feedback** — quality suggestions in the Checks side panel. Reads
@@ -89,6 +91,36 @@ adds it to `default_features`, but this project pins an explicit list in
 `WAGTAILADMIN_RICH_TEXT_EDITORS`, so `"ai"` must stay in that list
 (`tests/test_rich_text_features.py` guards it).
 
+## OpenStax voice rewrite
+Our own Draftail control, separate from wagtail-ai's wand, because the wand
+posts `getPlainText()` and pastes the reply back as plain text: it cannot see
+where the field sits and it destroys links, emphasis, and block structure.
+
+The button rewrites the blocks the selection touches (the whole field when
+nothing is selected) and leaves everything else alone.
+
+- **No HTML crosses the wire.** The browser sends ContentState; the server
+  converts with Wagtail's own `ContentstateConverter`, so the field's real
+  feature list is applied in both directions and markup the model invents but
+  the field does not allow is dropped on the way back in. `draftail_features.py`
+  recovers that feature list by mapping the editor's option types (`BOLD`,
+  `header-two`) back to Wagtail feature names — converting with a narrower list
+  than the field allows would silently delete the editor's own markup.
+- **Context** (`rewrite_context.py`) comes from the *saved* page: title, page
+  type, the field's label, and the neighbouring copy. Unsaved edits are
+  invisible to it, which is fine — it is tone context, not source material.
+- **Voice** (`prompts.py`: `VOICE_RULES`, `VOICE_EXEMPLARS`, `voice_prompt`) is
+  static exemplars, not retrieval. `PageVectorIndex` embeds titles and meta
+  descriptions only, and retrieving from our own body copy would teach the model
+  the voice we are trying to move away from.
+- **Provider** is the any-llm `default` alias (Sonnet), not the legacy `llm`
+  BACKENDS path.
+
+Pieces: `views.py` (`/admin/ai-assist/rewrite/`), `rewrite.py`,
+`rewrite_context.py`, `draftail_features.py`, `wagtail_hooks.py`,
+`static/ai_assist/draftail_rewrite.js`. Tests in `tests/test_rewrite.py`; the JS
+has no test harness in this repo, so the editor side is checked by hand.
+
 ## Related pages
 `PageVectorIndex` (in `vector_index.py`) indexes NewsArticle, Book, and FlexPage
 (title + search_description). Each exposes a "Related pages" chooser
@@ -100,6 +132,7 @@ once the key is set and `rebuild_indexes` has run.
 ## Manual QA (staging)
 - [ ] `python manage.py check_ai_config` passes.
 - [ ] Rich-text toolbar shows the AI wand + the seeded "Improve writing (OpenStax voice)" prompt.
+- [ ] The OpenStax voice button rewrites a selection, keeps its links and bold, and leaves the rest of the field alone.
 - [ ] Title and meta-description fields show the AI suggestion button.
 - [ ] Image editor offers alt-text generation; StreamField image blocks too.
 - [ ] Content feedback appears in the Checks panel.

--- a/ai_assist/draftail_features.py
+++ b/ai_assist/draftail_features.py
@@ -1,0 +1,55 @@
+"""Map a Draftail editor's client-side options back to Wagtail feature names.
+
+The rewrite endpoint round-trips content through
+``ContentstateConverter(features)``, which silently drops anything outside
+``features`` — so converting with a narrower list than the field actually allows
+would delete the editor's own markup. The browser knows which plugins its editor
+was built with (Wagtail renders them into ``data-w-init-detail-value``) but not
+what Wagtail calls them, so the type names are translated back here.
+"""
+
+from wagtail.rich_text import features as feature_registry
+
+# Every options key Wagtail's ListFeature subclasses write into (see
+# wagtail.admin.rich_text.editors.draftail.features).
+_LIST_OPTIONS = ("entityTypes", "blockTypes", "inlineStyles", "decorators", "controls")
+
+
+def _draftail_feature_index():
+    # Forces the register_rich_text_features hooks to run before we read the registry.
+    feature_registry.get_default_features()
+    plugins = feature_registry.plugins_by_editor.get("draftail", {})
+
+    by_type = {}
+    by_flag = {}
+    for name, plugin in plugins.items():
+        data = getattr(plugin, "data", None)
+        if isinstance(data, dict) and "type" in data:
+            by_type[data["type"]] = name
+        elif getattr(plugin, "option_name", None):
+            by_flag[plugin.option_name] = name
+    return by_type, by_flag
+
+
+def features_from_editor_options(options):
+    """Return the Wagtail feature names behind a Draftail options dict.
+
+    Falls back to the default feature set when nothing maps, so a payload we
+    don't understand degrades to "keep the usual markup" rather than to
+    "strip everything".
+    """
+    by_type, by_flag = _draftail_feature_index()
+
+    names = []
+    for key in _LIST_OPTIONS:
+        for item in options.get(key) or []:
+            if isinstance(item, dict):
+                name = by_type.get(item.get("type"))
+                if name:
+                    names.append(name)
+
+    for flag, name in by_flag.items():
+        if options.get(flag):
+            names.append(name)
+
+    return names or list(feature_registry.get_default_features())

--- a/ai_assist/prompts.py
+++ b/ai_assist/prompts.py
@@ -41,3 +41,70 @@ OPENSTAX_PROMPTS = [
         "method": "REPLACE",
     },
 ]
+
+
+# Exemplars, not retrieval: the vector index embeds titles and meta descriptions
+# only, and retrieving from our own body copy would teach the model the voice we
+# are trying to move away from.
+VOICE_EXEMPLARS = [
+    (
+        "OpenStax leverages cutting-edge technology to deliver best-in-class "
+        "learning solutions that empower educators to drive student outcomes.",
+        "OpenStax builds free textbooks and learning tools that teachers can use "
+        "the day they find them.",
+    ),
+    (
+        "Our revolutionary platform has disrupted the textbook industry, saving "
+        "students an unprecedented $2 billion and counting!",
+        "Students have saved more than $2 billion using OpenStax books instead of "
+        "buying commercial textbooks.",
+    ),
+    (
+        "Faculty may utilize the aforementioned ancillary resources subsequent to "
+        "verification of their instructor status.",
+        "Once we confirm you teach the course, you can download the instructor "
+        "resources.",
+    ),
+]
+
+VOICE_RULES = """You are rewriting copy for openstax.org.
+
+OpenStax is a nonprofit educational initiative at Rice University. We publish
+free, openly licensed textbooks and learning tools, and we sell a few paid
+platforms such as OpenStax Assignable.
+
+Voice:
+- Mission-driven, accessible, warm.
+- Plain language over jargon. If a faculty member or student could not follow
+  it, it is wrong.
+- Confident about our impact without bragging. No hype, no over-promising, no
+  exclamation marks.
+- Say what something is and what the reader can do with it.
+
+House terms: an "adoption" is an instructor formally using an OpenStax book in a
+course; supporters and donors are "Mission Makers"; our two markets are HE and
+K12; "faculty" and "instructors" are interchangeable, and K12 uses "teacher"."""
+
+
+def voice_prompt(brief, allowed_tags):
+    """Build the instruction sent alongside the HTML fragment being rewritten."""
+    examples = "\n\n".join(
+        f"Before: {before}\nAfter: {after}" for before, after in VOICE_EXEMPLARS
+    )
+    return f"""{VOICE_RULES}
+
+Examples of the rewrite:
+
+{examples}
+
+{brief}
+
+Rewrite the HTML fragment the user sends you.
+
+Rules for your reply:
+- Return HTML only. No markdown, no code fences, no commentary.
+- Keep every factual claim, name, number, and link target unchanged.
+- Keep the existing markup: same links, same emphasis, same headings, same
+  number of blocks, in the same order.
+- Use only these tags: {allowed_tags}.
+- Keep the length within about a quarter of the original."""

--- a/ai_assist/rewrite.py
+++ b/ai_assist/rewrite.py
@@ -1,0 +1,78 @@
+"""Rewrite a fragment of Draftail content in the OpenStax voice.
+
+The browser sends ContentState, not HTML: Wagtail's own converter turns it into
+the database HTML, and back again afterwards. That reuses the field's real
+feature list in both directions, so whatever the model invents that the field
+does not allow is dropped on the way in rather than sanitised by hand.
+"""
+
+import json
+import logging
+import re
+
+from wagtail.admin.rich_text.converters.contentstate import ContentstateConverter
+from wagtail.rich_text import features as feature_registry
+from wagtail_ai.agents.base import get_llm_service
+
+from .prompts import voice_prompt
+from .draftail_features import features_from_editor_options
+
+logger = logging.getLogger(__name__)
+
+PROVIDER_ALIAS = "default"
+MAX_HTML_CHARS = 12000
+
+_FENCE = re.compile(r"\A```[a-z]*\s*|\s*```\Z", re.IGNORECASE)
+
+
+class RewriteError(Exception):
+    """Something went wrong that the editor should be told about."""
+
+
+def allowed_tags(features):
+    tags = set()
+    for feature in features:
+        rule = feature_registry.get_converter_rule("contentstate", feature) or {}
+        for selector in rule.get("from_database_format", {}):
+            tags.add(selector.split("[")[0])
+    return ", ".join(f"<{tag}>" for tag in sorted(tags)) or "<p>"
+
+
+def _completion(instruction, html):
+    service = get_llm_service(alias=PROVIDER_ALIAS)
+    result = service.completion(
+        messages=[
+            {"role": "system", "content": instruction},
+            {"role": "user", "content": html},
+        ]
+    )
+    return result.choices[0].message.content
+
+
+def rewrite_contentstate(*, contentstate, editor_options, brief):
+    """Return the rewritten ContentState for one fragment of a rich text field."""
+    features = features_from_editor_options(editor_options)
+    converter = ContentstateConverter(features)
+
+    if not any(block.get("text", "").strip() for block in contentstate["blocks"]):
+        raise RewriteError("There's no text here to rewrite.")
+
+    html = converter.to_database_format(json.dumps(contentstate))
+    if len(html) > MAX_HTML_CHARS:
+        raise RewriteError("That's too much text at once — select less of it.")
+
+    try:
+        reply = _completion(voice_prompt(brief, allowed_tags(features)), html)
+    except Exception as error:
+        logger.exception("OpenStax voice rewrite failed")
+        raise RewriteError("The rewrite service didn't answer. Try again.") from error
+
+    reply = _FENCE.sub("", (reply or "").strip())
+    if not reply:
+        raise RewriteError("The rewrite came back empty. Try again.")
+
+    rewritten = json.loads(converter.from_database_format(reply))
+    if not any(block.get("text", "").strip() for block in rewritten.get("blocks", [])):
+        # Everything the model sent was outside the field's feature list.
+        raise RewriteError("The rewrite didn't fit this field. Try again.")
+    return rewritten

--- a/ai_assist/rewrite_context.py
+++ b/ai_assist/rewrite_context.py
@@ -1,0 +1,67 @@
+"""Describe where a piece of rich text lives, so a rewrite can suit its place.
+
+The editor sends the page it is editing and the label of the field; everything
+else comes from the saved page. Unsaved edits are therefore invisible here —
+acceptable, because this is tone context, not source material.
+"""
+
+from django.utils.html import strip_tags
+from wagtail.blocks.list_block import ListValue
+from wagtail.blocks.stream_block import StreamValue
+from wagtail.blocks.struct_block import StructValue
+from wagtail.fields import RichTextField, StreamField
+from wagtail.models import Page
+from wagtail.rich_text import RichText
+
+NEIGHBOUR_CHARS = 1200
+
+
+def _plain_text(value, out):
+    if len(" ".join(out)) > NEIGHBOUR_CHARS:
+        return
+    if isinstance(value, RichText):
+        out.append(strip_tags(value.source))
+    elif isinstance(value, str):
+        out.append(strip_tags(value))
+    elif isinstance(value, StreamValue):
+        for child in value:
+            _plain_text(child.value, out)
+    elif isinstance(value, (StructValue, dict)):
+        for child in value.values():
+            _plain_text(child, out)
+    elif isinstance(value, (ListValue, list, tuple)):
+        for child in value:
+            _plain_text(child, out)
+
+
+def neighbouring_text(page):
+    out = []
+    for field in page._meta.get_fields():
+        if isinstance(field, (StreamField, RichTextField)):
+            _plain_text(getattr(page, field.name, None), out)
+    text = " ".join(part.strip() for part in out if part and part.strip())
+    return text[:NEIGHBOUR_CHARS]
+
+
+def build_brief(page_id=None, field_label=None):
+    """One paragraph telling the model what it is rewriting and where it sits."""
+    page = None
+    if page_id:
+        page = Page.objects.filter(pk=page_id).first()
+        page = page.specific if page else None
+
+    if page is None:
+        return "You do not know which page this text belongs to."
+
+    where = f'This text is on the page "{page.title}", a {page._meta.verbose_name}'
+    if field_label:
+        where += f', in the "{field_label}" field'
+    lines = [where + "."]
+
+    neighbours = neighbouring_text(page)
+    if neighbours:
+        lines.append(
+            "The rest of the page reads like this — match it, and do not repeat "
+            f"it: {neighbours}"
+        )
+    return "\n\n".join(lines)

--- a/ai_assist/static/ai_assist/draftail_rewrite.js
+++ b/ai_assist/static/ai_assist/draftail_rewrite.js
@@ -1,0 +1,142 @@
+// Draftail control: rewrite the selected blocks in the OpenStax voice.
+//
+// Wagtail's own converter does the HTML round trip server-side, so this only
+// ever moves ContentState across the wire — nothing here needs to know which
+// tags the field allows.
+(() => {
+  const configElement = document.getElementById('ai-assist-config');
+  if (!configElement || !window.draftail || !window.DraftJS) {
+    return;
+  }
+  const config = JSON.parse(configElement.textContent);
+  const { ContentState, EditorState, Modifier, SelectionState, convertFromRaw, convertToRaw } =
+    window.DraftJS;
+
+  const selectedBlocks = (content, selection) => {
+    if (selection.isCollapsed()) {
+      return content.getBlocksAsArray();
+    }
+    const startKey = selection.getStartKey();
+    const endKey = selection.getEndKey();
+    return content
+      .getBlockMap()
+      .skipUntil((_, key) => key === startKey)
+      .takeUntil((_, key) => key === endKey)
+      .toArray()
+      .concat([content.getBlockForKey(endKey)]);
+  };
+
+  const wholeBlocks = (blocks) => {
+    const first = blocks[0];
+    const last = blocks[blocks.length - 1];
+    return SelectionState.createEmpty(first.getKey()).merge({
+      anchorKey: first.getKey(),
+      anchorOffset: 0,
+      focusKey: last.getKey(),
+      focusOffset: last.getLength(),
+      isBackward: false,
+    });
+  };
+
+  const editorInput = (element) => {
+    const wrapper = element && element.closest('[data-draftail-editor-wrapper]');
+    // Wagtail appends the wrapper next to the hidden input it initialised from.
+    return wrapper && wrapper.parentNode.querySelector('[data-draftail-input]');
+  };
+
+  const editorOptions = (input) => {
+    try {
+      return JSON.parse(input.getAttribute('data-w-init-detail-value') || '{}');
+    } catch (error) {
+      return {};
+    }
+  };
+
+  const fieldLabel = (input) => {
+    const field = input.closest('[data-field-wrapper], .w-field__wrapper');
+    const label = field && field.querySelector('label');
+    return label ? label.textContent.trim() : '';
+  };
+
+  const currentPageId = () => {
+    const match = window.location.pathname.match(/\/pages\/(\d+)\/edit/);
+    return match ? match[1] : null;
+  };
+
+  const requestRewrite = async (body, signal) => {
+    const response = await fetch(config.rewriteUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        [window.wagtailConfig.CSRF_HEADER_NAME]: window.wagtailConfig.CSRF_TOKEN,
+      },
+      body: JSON.stringify(body),
+      signal,
+    });
+    const data = await response.json();
+    if (!response.ok) {
+      throw new Error(data.error || 'The rewrite failed.');
+    }
+    return data.contentstate;
+  };
+
+  const OpenStaxVoiceControl = ({ getEditorState, onChange }) => {
+    const [busy, setBusy] = window.React.useState(false);
+    const [error, setError] = window.React.useState(null);
+    const anchor = window.React.useRef();
+
+    const rewrite = async () => {
+      const input = editorInput(anchor.current);
+      if (!input || busy) {
+        return;
+      }
+      const editorState = getEditorState();
+      const content = editorState.getCurrentContent();
+      const blocks = selectedBlocks(content, editorState.getSelection());
+      const fragment = ContentState.createFromBlockArray(blocks, content.getEntityMap());
+
+      setError(null);
+      setBusy(true);
+      try {
+        const rewritten = await requestRewrite({
+          contentstate: convertToRaw(fragment),
+          editorOptions: editorOptions(input),
+          pageId: currentPageId(),
+          fieldLabel: fieldLabel(input),
+        });
+        const replacement = Modifier.replaceWithFragment(
+          content,
+          wholeBlocks(blocks),
+          convertFromRaw(rewritten).getBlockMap(),
+        );
+        onChange(EditorState.push(editorState, replacement, 'insert-fragment'));
+      } catch (requestError) {
+        setError(requestError.message);
+      } finally {
+        setBusy(false);
+      }
+    };
+
+    return window.React.createElement(
+      window.React.Fragment,
+      null,
+      window.React.createElement(window.Draftail.ToolbarButton, {
+        name: 'OPENSTAX_VOICE',
+        title: busy ? 'Rewriting…' : 'Rewrite in OpenStax voice',
+        icon: window.React.createElement(window.Draftail.Icon, {
+          icon: busy ? '#icon-spinner' : '#icon-wand',
+        }),
+        onClick: rewrite,
+      }),
+      window.React.createElement('span', { ref: anchor }),
+      error
+        ? window.React.createElement('span', { className: 'error-message' }, error)
+        : null,
+    );
+  };
+
+  window.draftail.registerPlugin(
+    { type: 'openstax-voice', inline: OpenStaxVoiceControl },
+    'controls',
+  );
+})();

--- a/ai_assist/tests/test_rewrite.py
+++ b/ai_assist/tests/test_rewrite.py
@@ -1,0 +1,228 @@
+import json
+from types import SimpleNamespace
+from unittest import mock
+
+from django.core.serializers.json import DjangoJSONEncoder
+from django.test import TestCase
+from django.urls import reverse
+from wagtail.admin.rich_text import DraftailRichTextArea
+from wagtail.admin.rich_text.converters.contentstate import ContentstateConverter
+from wagtail.models import Page
+from wagtail.rich_text import RichText
+from wagtail.test.utils import WagtailTestUtils
+
+from ai_assist.draftail_features import features_from_editor_options
+from ai_assist.rewrite import MAX_HTML_CHARS, RewriteError, allowed_tags, rewrite_contentstate
+from ai_assist.rewrite_context import build_brief
+from pages.models import GeneralPage
+
+FEATURES = ["bold", "italic", "link", "h2", "hr"]
+SAMPLE_HTML = '<p>Hello <b>world</b> <a href="https://openstax.org">here</a>.</p>'
+
+
+def contentstate_for(html, features=FEATURES):
+    return json.loads(ContentstateConverter(features).from_database_format(html))
+
+
+def editor_options(features=FEATURES):
+    # Wagtail's options hold lazy translations; the browser only ever sees them
+    # after DjangoJSONEncoder has been through them, so match that here.
+    options = DraftailRichTextArea(features=features).options
+    return json.loads(json.dumps(options, cls=DjangoJSONEncoder))
+
+
+def fake_service(reply, recorder=None):
+    def completion(messages, **kwargs):
+        if recorder is not None:
+            recorder.extend(messages)
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content=reply))]
+        )
+
+    return mock.Mock(return_value=SimpleNamespace(completion=completion))
+
+
+class EditorOptionMappingTests(TestCase):
+    def test_option_types_map_back_to_feature_names(self):
+        # The browser knows 'BOLD' and 'header-two'; the converter needs
+        # 'bold' and 'h2', and getting it wrong silently deletes markup.
+        self.assertEqual(
+            set(features_from_editor_options(editor_options())), set(FEATURES)
+        )
+
+    def test_unrecognised_options_fall_back_to_the_default_features(self):
+        from wagtail.rich_text import features as feature_registry
+
+        self.assertEqual(
+            features_from_editor_options({"entityTypes": [{"type": "NOPE"}]}),
+            list(feature_registry.get_default_features()),
+        )
+
+    def test_allowed_tags_come_from_the_feature_list(self):
+        tags = allowed_tags(["bold", "link"])
+        self.assertIn("<b>", tags)
+        self.assertIn("<a>", tags)
+        self.assertNotIn("<h2>", tags)
+
+
+class RewriteContentstateTests(TestCase):
+    def rewrite(self, reply, html=SAMPLE_HTML, recorder=None):
+        with mock.patch(
+            "ai_assist.rewrite.get_llm_service", fake_service(reply, recorder)
+        ):
+            return rewrite_contentstate(
+                contentstate=contentstate_for(html),
+                editor_options=editor_options(),
+                brief="This text is on the page \"Give\".",
+            )
+
+    def test_inline_formatting_and_links_survive_the_round_trip(self):
+        rewritten = self.rewrite(
+            '<p>Hi <b>there</b> <a href="https://openstax.org">friend</a>.</p>'
+        )
+
+        block = rewritten["blocks"][0]
+        self.assertEqual(block["text"], "Hi there friend.")
+        self.assertEqual(
+            [style["style"] for style in block["inlineStyleRanges"]], ["BOLD"]
+        )
+        self.assertEqual(len(block["entityRanges"]), 1)
+        self.assertEqual(
+            list(rewritten["entityMap"].values())[0]["data"]["url"],
+            "https://openstax.org",
+        )
+
+    def test_the_prompt_carries_the_brief_and_the_fragment(self):
+        messages = []
+        self.rewrite("<p>Hi.</p>", recorder=messages)
+
+        system, user = messages
+        self.assertIn('This text is on the page "Give".', system["content"])
+        self.assertIn("OpenStax", system["content"])
+        self.assertIn("Hello", user["content"])
+
+    def test_code_fences_are_stripped(self):
+        rewritten = self.rewrite("```html\n<p>Fenced.</p>\n```")
+
+        self.assertEqual(rewritten["blocks"][0]["text"], "Fenced.")
+
+    def test_markup_the_field_does_not_allow_is_dropped(self):
+        rewritten = self.rewrite(
+            "<p>Kept.</p><table><tr><td>Nope</td></tr></table>"
+            "<h1>Also nope</h1><script>alert(1)</script>"
+        )
+
+        types = {block["type"] for block in rewritten["blocks"]}
+        self.assertEqual(types, {"unstyled"})
+        self.assertNotIn("header-one", types)
+
+    def test_a_reply_with_nothing_usable_is_an_error(self):
+        with self.assertRaises(RewriteError):
+            self.rewrite("   ")
+
+    def test_an_empty_fragment_is_an_error(self):
+        with self.assertRaises(RewriteError):
+            self.rewrite("<p>anything</p>", html="<p></p>")
+
+    def test_an_oversized_fragment_is_an_error(self):
+        with self.assertRaises(RewriteError):
+            self.rewrite("<p>ok</p>", html=f"<p>{'x' * MAX_HTML_CHARS}</p>")
+
+    def test_a_provider_failure_becomes_a_rewrite_error(self):
+        service = mock.Mock(
+            return_value=SimpleNamespace(
+                completion=mock.Mock(side_effect=RuntimeError("boom"))
+            )
+        )
+        with mock.patch("ai_assist.rewrite.get_llm_service", service):
+            with self.assertRaises(RewriteError):
+                rewrite_contentstate(
+                    contentstate=contentstate_for(SAMPLE_HTML),
+                    editor_options=editor_options(),
+                    brief="",
+                )
+
+
+class BuildBriefTests(TestCase):
+    def setUp(self):
+        root = Page.objects.get(title="Root")
+        self.page = GeneralPage(
+            title="Give",
+            slug="give-brief",
+            body=[
+                ("heading", "Give today"),
+                ("paragraph", RichText("<p>Every gift keeps our books free.</p>")),
+            ],
+        )
+        root.add_child(instance=self.page)
+
+    def test_brief_names_the_page_and_quotes_its_other_copy(self):
+        brief = build_brief(page_id=self.page.pk, field_label="Body")
+
+        self.assertIn('"Give"', brief)
+        self.assertIn("Body", brief)
+        self.assertIn("Every gift keeps our books free.", brief)
+
+    def test_brief_says_so_when_the_page_is_unknown(self):
+        self.assertIn("do not know", build_brief(page_id=None))
+
+
+class RewriteViewTests(TestCase, WagtailTestUtils):
+    def setUp(self):
+        self.url = reverse("ai_assist_rewrite")
+        self.payload = {
+            "contentstate": contentstate_for(SAMPLE_HTML),
+            "editorOptions": editor_options(),
+            "pageId": None,
+            "fieldLabel": "Text",
+        }
+
+    def post(self, payload):
+        return self.client.post(
+            self.url, data=json.dumps(payload), content_type="application/json"
+        )
+
+    def test_admin_access_is_required(self):
+        response = self.post(self.payload)
+
+        self.assertNotEqual(response.status_code, 200)
+
+    def test_logged_in_editor_gets_the_rewritten_contentstate(self):
+        self.login()
+        with mock.patch(
+            "ai_assist.rewrite.get_llm_service", fake_service("<p>Rewritten.</p>")
+        ):
+            response = self.post(self.payload)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json()["contentstate"]["blocks"][0]["text"], "Rewritten."
+        )
+
+    def test_a_malformed_payload_is_rejected(self):
+        self.login()
+
+        self.assertEqual(self.post({"contentstate": "nope"}).status_code, 400)
+
+    def test_a_rewrite_error_comes_back_as_a_message(self):
+        self.login()
+        with mock.patch("ai_assist.rewrite.get_llm_service", fake_service("")):
+            response = self.post(self.payload)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("error", response.json())
+
+    def test_get_is_not_allowed(self):
+        self.login()
+
+        self.assertEqual(self.client.get(self.url).status_code, 405)
+
+
+class AdminAssetTests(TestCase):
+    def test_the_control_script_is_injected_with_its_endpoint(self):
+        from ai_assist.wagtail_hooks import ai_assist_draftail_js
+
+        markup = ai_assist_draftail_js()
+
+        self.assertIn("ai_assist/draftail_rewrite.js", markup)
+        self.assertIn(reverse("ai_assist_rewrite"), markup)

--- a/ai_assist/views.py
+++ b/ai_assist/views.py
@@ -1,0 +1,54 @@
+import json
+
+from django.http import JsonResponse
+from django.views.decorators.http import require_POST
+from wagtail.admin.auth import require_admin_access
+
+from .rewrite import RewriteError, rewrite_contentstate
+from .rewrite_context import build_brief
+
+MAX_LABEL_CHARS = 100
+
+
+def _page_id(value):
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+@require_admin_access
+@require_POST
+def rewrite(request):
+    try:
+        payload = json.loads(request.body)
+    except (ValueError, UnicodeDecodeError):
+        return JsonResponse({"error": "Invalid request."}, status=400)
+
+    if not isinstance(payload, dict):
+        return JsonResponse({"error": "Invalid request."}, status=400)
+
+    contentstate = payload.get("contentstate")
+    editor_options = payload.get("editorOptions") or {}
+    if (
+        not isinstance(contentstate, dict)
+        or not isinstance(contentstate.get("blocks"), list)
+        or not isinstance(editor_options, dict)
+    ):
+        return JsonResponse({"error": "Invalid request."}, status=400)
+
+    brief = build_brief(
+        page_id=_page_id(payload.get("pageId")),
+        field_label=str(payload.get("fieldLabel") or "")[:MAX_LABEL_CHARS],
+    )
+
+    try:
+        rewritten = rewrite_contentstate(
+            contentstate=contentstate,
+            editor_options=editor_options,
+            brief=brief,
+        )
+    except RewriteError as error:
+        return JsonResponse({"error": str(error)}, status=400)
+
+    return JsonResponse({"contentstate": rewritten})

--- a/ai_assist/wagtail_hooks.py
+++ b/ai_assist/wagtail_hooks.py
@@ -1,0 +1,21 @@
+from django.urls import path, reverse
+from django.utils.html import format_html, json_script
+from wagtail import hooks
+from wagtail.admin.staticfiles import versioned_static
+
+from .views import rewrite
+
+
+@hooks.register("register_admin_urls")
+def register_ai_assist_urls():
+    return [path("ai-assist/rewrite/", rewrite, name="ai_assist_rewrite")]
+
+
+@hooks.register("insert_global_admin_js")
+def ai_assist_draftail_js():
+    config = {"rewriteUrl": reverse("ai_assist_rewrite")}
+    return format_html(
+        '{}<script src="{}"></script>',
+        json_script(config, "ai-assist-config"),
+        versioned_static("ai_assist/draftail_rewrite.js"),
+    )


### PR DESCRIPTION
Adds a second Draftail toolbar button next to wagtail-ai's wand: **Rewrite in OpenStax voice**.

### Why
wagtail-ai's wand posts `editorState.getCurrentContent().getPlainText()` and pastes the reply back with `Modifier.replaceText` over the whole document. So it can't tell an eyebrow from a body paragraph, and it destroys links, bold, and block structure on every run.

### How
- The browser sends **ContentState**, never HTML — for the blocks the selection touches, or the whole field when nothing is selected.
- The server converts with Wagtail's own `ContentstateConverter`, using the field's **real feature list**, recovered by mapping the editor's option types (`BOLD`, `header-two`) back to Wagtail feature names (`ai_assist/draftail_features.py`). Anything the model invents that the field doesn't allow is dropped by Wagtail on the way in, so there's no hand-rolled sanitiser. Converting with a *narrower* list than the field allows would silently delete the editor's own markup — hence the mapping rather than a default list.
- The prompt carries a brief built from the **saved** page: title, page type, field label, neighbouring copy (`ai_assist/rewrite_context.py`). Unsaved edits are invisible to it; it's tone context, not source material.
- Voice guidance is **static exemplars** (`VOICE_RULES` / `VOICE_EXEMPLARS` in `ai_assist/prompts.py`), not retrieval: `PageVectorIndex` embeds titles and meta descriptions only, and retrieving our own body copy would teach the model the voice we're trying to move away from.
- Runs on the any-llm `default` alias (Sonnet), not the legacy `llm` BACKENDS path.

### Tests
19 new tests in `ai_assist/tests/test_rewrite.py` (feature mapping, round-trip fidelity for bold/links, disallowed markup dropped, code fences, empty/oversized/failed rewrites, brief assembly, view auth + payload validation). Full suite: 598 passing.

The Draftail control JS has no test harness in this repo, so the editor side needs a manual pass on dev:
- [ ] Button appears in the rich-text toolbar and rewrites a selection
- [ ] Links and bold survive; unselected blocks are untouched
- [ ] Undo restores the original in one step